### PR TITLE
Create DDS Reader only on remote Subscription

### DIFF
--- a/zenoh-plugin-ros2dds/src/dds_utils.rs
+++ b/zenoh-plugin-ros2dds/src/dds_utils.rs
@@ -20,7 +20,7 @@ use serde::Serializer;
 use std::{
     ffi::{CStr, CString},
     mem::MaybeUninit,
-    sync::Arc,
+    sync::{atomic::AtomicI32, Arc},
     time::Duration,
 };
 #[cfg(feature = "dds_shm")]
@@ -32,6 +32,11 @@ use crate::{
     vec_into_raw_parts,
 };
 
+const DDS_ENTITY_NULL: dds_entity_t = 0;
+
+// An atomic dds_entity_t (=i32), for safe concurrent creation/deletion of DDS entities
+type AtomicDDSEntity = AtomicI32;
+
 pub fn delete_dds_entity(entity: dds_entity_t) -> Result<(), String> {
     unsafe {
         let r = dds_delete(entity);
@@ -39,6 +44,15 @@ pub fn delete_dds_entity(entity: dds_entity_t) -> Result<(), String> {
             0 | DDS_RETCODE_ALREADY_DELETED => Ok(()),
             e => Err(format!("Error deleting DDS entity - retcode={e}")),
         }
+    }
+}
+
+pub(crate) fn delete_atomic_dds_entity(entity: &mut AtomicDDSEntity) -> Result<(), String> {
+    let dds_entity = entity.swap(DDS_ENTITY_NULL, std::sync::atomic::Ordering::Relaxed);
+    if dds_entity != DDS_ENTITY_NULL {
+        delete_dds_entity(dds_entity)
+    } else {
+        Ok(())
     }
 }
 
@@ -61,6 +75,16 @@ where
     match get_guid(entity) {
         Ok(guid) => s.serialize_str(&guid.to_string()),
         Err(_) => s.serialize_str("UNKOWN_GUID"),
+    }
+}
+
+pub fn serialize_atomic_entity_guid<S>(entity: &AtomicDDSEntity, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match entity.load(std::sync::atomic::Ordering::Relaxed) {
+        DDS_ENTITY_NULL => s.serialize_str(""),
+        entity => serialize_entity_guid(&entity, s),
     }
 }
 

--- a/zenoh-plugin-ros2dds/src/liveliness_mgt.rs
+++ b/zenoh-plugin-ros2dds/src/liveliness_mgt.rs
@@ -184,7 +184,6 @@ pub(crate) fn parse_ke_liveliness_service_cli(
     Ok((plugin_id, zenoh_key_expr, ros2_type.to_string()))
 }
 
-/////////
 pub(crate) fn new_ke_liveliness_action_srv(
     plugin_id: &keyexpr,
     zenoh_key_expr: &keyexpr,

--- a/zenoh-plugin-ros2dds/src/qos_helpers.rs
+++ b/zenoh-plugin-ros2dds/src/qos_helpers.rs
@@ -27,8 +27,8 @@ pub fn get_durability_service_or_default(qos: &Qos) -> DurabilityService {
     }
 }
 
-pub fn is_reader_reliable(reliability: &Option<Reliability>) -> bool {
-    reliability.as_ref().map_or(false, |reliability| {
+pub fn is_reliable(qos: &Qos) -> bool {
+    qos.reliability.as_ref().map_or(false, |reliability| {
         reliability.kind == ReliabilityKind::RELIABLE
     })
 }

--- a/zenoh-plugin-ros2dds/src/ros_discovery.rs
+++ b/zenoh-plugin-ros2dds/src/ros_discovery.rs
@@ -212,19 +212,6 @@ impl RosDiscoveryInfoMgr {
         *has_changed = true;
     }
 
-    pub fn add_dds_writers(&self, gids: Vec<Gid>) {
-        let (ref mut info, ref mut has_changed) = *zwrite!(self.participant_entities_state);
-        let writer_gid_seq = &mut info
-            .node_entities_info_seq
-            .get_mut(&self.node_fullname)
-            .unwrap()
-            .writer_gid_seq;
-        for gid in gids {
-            writer_gid_seq.insert(gid);
-        }
-        *has_changed = true;
-    }
-
     pub fn remove_dds_writer(&self, gid: Gid) {
         let (ref mut info, ref mut has_changed) = *zwrite!(self.participant_entities_state);
         info.node_entities_info_seq
@@ -242,19 +229,6 @@ impl RosDiscoveryInfoMgr {
             .unwrap()
             .reader_gid_seq
             .insert(gid);
-        *has_changed = true;
-    }
-
-    pub fn add_dds_readers(&self, gids: Vec<Gid>) {
-        let (ref mut info, ref mut has_changed) = *zwrite!(self.participant_entities_state);
-        let reader_gid_seq = &mut info
-            .node_entities_info_seq
-            .get_mut(&self.node_fullname)
-            .unwrap()
-            .reader_gid_seq;
-        for gid in gids {
-            reader_gid_seq.insert(gid);
-        }
         *has_changed = true;
     }
 

--- a/zenoh-plugin-ros2dds/src/ros_discovery.rs
+++ b/zenoh-plugin-ros2dds/src/ros_discovery.rs
@@ -235,19 +235,6 @@ impl RosDiscoveryInfoMgr {
         *has_changed = true;
     }
 
-    pub fn remove_dds_writers(&self, gids: Vec<Gid>) {
-        let (ref mut info, ref mut has_changed) = *zwrite!(self.participant_entities_state);
-        let writer_gid_seq = &mut info
-            .node_entities_info_seq
-            .get_mut(&self.node_fullname)
-            .unwrap()
-            .writer_gid_seq;
-        for gid in gids {
-            writer_gid_seq.remove(&gid);
-        }
-        *has_changed = true;
-    }
-
     pub fn add_dds_reader(&self, gid: Gid) {
         let (ref mut info, ref mut has_changed) = *zwrite!(self.participant_entities_state);
         info.node_entities_info_seq
@@ -278,19 +265,6 @@ impl RosDiscoveryInfoMgr {
             .unwrap()
             .reader_gid_seq
             .remove(&gid);
-        *has_changed = true;
-    }
-
-    pub fn remove_dds_readers(&self, gids: Vec<Gid>) {
-        let (ref mut info, ref mut has_changed) = *zwrite!(self.participant_entities_state);
-        let reader_gid_seq = &mut info
-            .node_entities_info_seq
-            .get_mut(&self.node_fullname)
-            .unwrap()
-            .reader_gid_seq;
-        for gid in gids {
-            reader_gid_seq.remove(&gid);
-        }
         *has_changed = true;
     }
 

--- a/zenoh-plugin-ros2dds/src/route_action_cli.rs
+++ b/zenoh-plugin-ros2dds/src/route_action_cli.rs
@@ -17,7 +17,7 @@ use zenoh::{liveliness::LivelinessToken, prelude::*};
 use zenoh_core::AsyncResolve;
 
 use crate::{
-    gid::Gid, liveliness_mgt::new_ke_liveliness_action_cli, ros2_utils::*,
+    liveliness_mgt::new_ke_liveliness_action_cli, ros2_utils::*,
     route_action_srv::serialize_action_zenoh_key_expr, route_service_cli::RouteServiceCli,
     route_subscriber::RouteSubscriber, routes_mgr::Context,
 };
@@ -169,26 +169,6 @@ impl RouteActionCli<'_> {
         // The DDS Writer remains to be discovered by local ROS nodes
         self.is_active = false;
         self.liveliness_token = None;
-    }
-
-    pub fn dds_writers_guids(&self) -> Result<Vec<Gid>, String> {
-        Ok([
-            self.route_send_goal.dds_rep_writer_guid()?,
-            self.route_cancel_goal.dds_rep_writer_guid()?,
-            self.route_get_result.dds_rep_writer_guid()?,
-            self.route_feedback.dds_writer_guid()?,
-            self.route_status.dds_writer_guid()?,
-        ]
-        .into())
-    }
-
-    pub fn dds_readers_guids(&self) -> Result<Vec<Gid>, String> {
-        Ok([
-            self.route_send_goal.dds_req_reader_guid()?,
-            self.route_cancel_goal.dds_req_reader_guid()?,
-            self.route_get_result.dds_req_reader_guid()?,
-        ]
-        .into())
     }
 
     #[inline]

--- a/zenoh-plugin-ros2dds/src/route_action_cli.rs
+++ b/zenoh-plugin-ros2dds/src/route_action_cli.rs
@@ -11,16 +11,15 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use cyclors::dds_entity_t;
 use serde::Serialize;
-use std::{collections::HashSet, fmt, sync::Arc};
+use std::{collections::HashSet, fmt};
 use zenoh::{liveliness::LivelinessToken, prelude::*};
 use zenoh_core::AsyncResolve;
 
 use crate::{
-    config::Config, gid::Gid, liveliness_mgt::new_ke_liveliness_action_cli, ros2_utils::*,
+    gid::Gid, liveliness_mgt::new_ke_liveliness_action_cli, ros2_utils::*,
     route_action_srv::serialize_action_zenoh_key_expr, route_service_cli::RouteServiceCli,
-    route_subscriber::RouteSubscriber,
+    route_subscriber::RouteSubscriber, routes_mgr::Context,
 };
 
 #[derive(Serialize)]
@@ -35,12 +34,9 @@ pub struct RouteActionCli<'a> {
         serialize_with = "serialize_action_zenoh_key_expr"
     )]
     zenoh_key_expr_prefix: OwnedKeyExpr,
-    // the zenoh session
+    // the context
     #[serde(skip)]
-    zsession: &'a Arc<Session>,
-    // the config
-    #[serde(skip)]
-    _config: Arc<Config>,
+    context: Context<'a>,
     is_active: bool,
     #[serde(skip)]
     route_send_goal: RouteServiceCli<'a>,
@@ -73,68 +69,56 @@ impl fmt::Display for RouteActionCli<'_> {
 
 impl RouteActionCli<'_> {
     #[allow(clippy::too_many_arguments)]
-    pub async fn create(
-        config: Arc<Config>,
-        zsession: &Arc<Session>,
-        participant: dds_entity_t,
+    pub async fn create<'a>(
         ros2_name: String,
         ros2_type: String,
         zenoh_key_expr_prefix: OwnedKeyExpr,
-    ) -> Result<RouteActionCli<'_>, String> {
+        context: &Context<'a>,
+    ) -> Result<RouteActionCli<'a>, String> {
         let route_send_goal = RouteServiceCli::create(
-            config.clone(),
-            zsession,
-            participant,
             format!("{ros2_name}/{}", *KE_SUFFIX_ACTION_SEND_GOAL),
             format!("{ros2_type}_SendGoal"),
             &zenoh_key_expr_prefix / *KE_SUFFIX_ACTION_SEND_GOAL,
             &None,
+            context,
         )
         .await?;
 
         let route_cancel_goal = RouteServiceCli::create(
-            config.clone(),
-            zsession,
-            participant,
             format!("{ros2_name}/{}", *KE_SUFFIX_ACTION_CANCEL_GOAL),
             ROS2_ACTION_CANCEL_GOAL_SRV_TYPE.to_string(),
             &zenoh_key_expr_prefix / *KE_SUFFIX_ACTION_CANCEL_GOAL,
             &None,
+            context,
         )
         .await?;
 
         let route_get_result = RouteServiceCli::create(
-            config.clone(),
-            zsession,
-            participant,
             format!("{ros2_name}/{}", *KE_SUFFIX_ACTION_GET_RESULT),
             format!("{ros2_type}_GetResult"),
             &zenoh_key_expr_prefix / *KE_SUFFIX_ACTION_GET_RESULT,
             &None,
+            context,
         )
         .await?;
 
         let route_feedback = RouteSubscriber::create(
-            config.clone(),
-            zsession,
-            participant,
             format!("{ros2_name}/{}", *KE_SUFFIX_ACTION_FEEDBACK),
             format!("{ros2_type}_FeedbackMessage"),
             &zenoh_key_expr_prefix / *KE_SUFFIX_ACTION_FEEDBACK,
             true,
             QOS_ACTION_FEEDBACK.clone(),
+            context,
         )
         .await?;
 
         let route_status = RouteSubscriber::create(
-            config.clone(),
-            zsession,
-            participant,
             format!("{ros2_name}/{}", *KE_SUFFIX_ACTION_STATUS),
             ROS2_ACTION_STATUS_MSG_TYPE.to_string(),
             &zenoh_key_expr_prefix / *KE_SUFFIX_ACTION_STATUS,
             true,
             QOS_ACTION_STATUS.clone(),
+            context,
         )
         .await?;
 
@@ -142,8 +126,7 @@ impl RouteActionCli<'_> {
             ros2_name,
             ros2_type,
             zenoh_key_expr_prefix,
-            zsession,
-            _config: config,
+            context: context.clone(),
             is_active: false,
             route_send_goal,
             route_cancel_goal,
@@ -156,14 +139,17 @@ impl RouteActionCli<'_> {
         })
     }
 
-    async fn activate<'a>(&'a mut self, plugin_id: &keyexpr) -> Result<(), String> {
+    async fn activate<'a>(&'a mut self) -> Result<(), String> {
         self.is_active = true;
 
         // create associated LivelinessToken
-        let liveliness_ke =
-            new_ke_liveliness_action_cli(plugin_id, &self.zenoh_key_expr_prefix, &self.ros2_type)?;
+        let liveliness_ke = new_ke_liveliness_action_cli(
+            &self.context.plugin_id,
+            &self.zenoh_key_expr_prefix,
+            &self.ros2_type,
+        )?;
         let ros2_name = self.ros2_name.clone();
-        self.liveliness_token = Some(self.zsession
+        self.liveliness_token = Some(self.context.zsession
             .liveliness()
             .declare_token(liveliness_ke)
             .res_async()
@@ -260,24 +246,22 @@ impl RouteActionCli<'_> {
     }
 
     #[inline]
-    pub async fn add_local_node(&mut self, node: String, plugin_id: &keyexpr) {
+    pub async fn add_local_node(&mut self, node: String) {
         futures::join!(
-            self.route_send_goal.add_local_node(node.clone(), plugin_id),
-            self.route_cancel_goal
-                .add_local_node(node.clone(), plugin_id),
-            self.route_get_result
-                .add_local_node(node.clone(), plugin_id),
+            self.route_send_goal.add_local_node(node.clone()),
+            self.route_cancel_goal.add_local_node(node.clone()),
+            self.route_get_result.add_local_node(node.clone()),
             self.route_feedback
-                .add_local_node(node.clone(), plugin_id, &QOS_ACTION_FEEDBACK),
+                .add_local_node(node.clone(), &QOS_ACTION_FEEDBACK),
             self.route_status
-                .add_local_node(node.clone(), plugin_id, &QOS_ACTION_STATUS),
+                .add_local_node(node.clone(), &QOS_ACTION_STATUS),
         );
 
         self.local_nodes.insert(node);
         log::debug!("{self} now serving local nodes {:?}", self.local_nodes);
         // if 1st local node added, activate the route
         if self.local_nodes.len() == 1 {
-            if let Err(e) = self.activate(plugin_id).await {
+            if let Err(e) = self.activate().await {
                 log::error!("{self} activation failed: {e}");
             }
         }

--- a/zenoh-plugin-ros2dds/src/route_action_srv.rs
+++ b/zenoh-plugin-ros2dds/src/route_action_srv.rs
@@ -11,15 +11,14 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use cyclors::dds_entity_t;
 use serde::{Serialize, Serializer};
-use std::{collections::HashSet, fmt, sync::Arc};
+use std::{collections::HashSet, fmt};
 use zenoh::{liveliness::LivelinessToken, prelude::*};
 use zenoh_core::AsyncResolve;
 
 use crate::{
-    config::Config, gid::Gid, liveliness_mgt::new_ke_liveliness_action_srv, ros2_utils::*,
-    route_publisher::RoutePublisher, route_service_srv::RouteServiceSrv,
+    gid::Gid, liveliness_mgt::new_ke_liveliness_action_srv, ros2_utils::*,
+    route_publisher::RoutePublisher, route_service_srv::RouteServiceSrv, routes_mgr::Context,
 };
 
 #[derive(Serialize)]
@@ -34,12 +33,9 @@ pub struct RouteActionSrv<'a> {
         serialize_with = "serialize_action_zenoh_key_expr"
     )]
     zenoh_key_expr_prefix: OwnedKeyExpr,
-    // the zenoh session
+    // the context
     #[serde(skip)]
-    zsession: &'a Arc<Session>,
-    // the config
-    #[serde(skip)]
-    _config: Arc<Config>,
+    context: Context<'a>,
     is_active: bool,
     #[serde(skip)]
     route_send_goal: RouteServiceSrv<'a>,
@@ -72,70 +68,58 @@ impl fmt::Display for RouteActionSrv<'_> {
 
 impl RouteActionSrv<'_> {
     #[allow(clippy::too_many_arguments)]
-    pub async fn create(
-        config: Arc<Config>,
-        zsession: &Arc<Session>,
-        participant: dds_entity_t,
+    pub async fn create<'a>(
         ros2_name: String,
         ros2_type: String,
         zenoh_key_expr_prefix: OwnedKeyExpr,
-    ) -> Result<RouteActionSrv<'_>, String> {
+        context: &Context<'a>,
+    ) -> Result<RouteActionSrv<'a>, String> {
         let route_send_goal = RouteServiceSrv::create(
-            config.clone(),
-            zsession,
-            participant,
             format!("{ros2_name}/{}", *KE_SUFFIX_ACTION_SEND_GOAL),
             format!("{ros2_type}_SendGoal"),
             &zenoh_key_expr_prefix / *KE_SUFFIX_ACTION_SEND_GOAL,
             &None,
+            context,
         )
         .await?;
 
         let route_cancel_goal = RouteServiceSrv::create(
-            config.clone(),
-            zsession,
-            participant,
             format!("{ros2_name}/{}", *KE_SUFFIX_ACTION_CANCEL_GOAL),
             ROS2_ACTION_CANCEL_GOAL_SRV_TYPE.to_string(),
             &zenoh_key_expr_prefix / *KE_SUFFIX_ACTION_CANCEL_GOAL,
             &None,
+            context,
         )
         .await?;
 
         let route_get_result = RouteServiceSrv::create(
-            config.clone(),
-            zsession,
-            participant,
             format!("{ros2_name}/{}", *KE_SUFFIX_ACTION_GET_RESULT),
             format!("{ros2_type}_GetResult"),
             &zenoh_key_expr_prefix / *KE_SUFFIX_ACTION_GET_RESULT,
             &None,
+            context,
         )
         .await?;
 
         let route_feedback = RoutePublisher::create(
-            config.clone(),
-            zsession,
-            participant,
             format!("{ros2_name}/{}", *KE_SUFFIX_ACTION_FEEDBACK),
             format!("{ros2_type}_FeedbackMessage"),
             &zenoh_key_expr_prefix / *KE_SUFFIX_ACTION_FEEDBACK,
             &None,
             true,
             QOS_ACTION_FEEDBACK.clone(),
+            context,
         )
         .await?;
 
         let route_status = RoutePublisher::create(
-            config.clone(),
-            zsession,
-            participant,
             format!("{ros2_name}/{}", *KE_SUFFIX_ACTION_STATUS),
             ROS2_ACTION_STATUS_MSG_TYPE.to_string(),
             &zenoh_key_expr_prefix / *KE_SUFFIX_ACTION_STATUS,
             &None,
             true,
             QOS_ACTION_STATUS.clone(),
+            context,
         )
         .await?;
 
@@ -143,8 +127,7 @@ impl RouteActionSrv<'_> {
             ros2_name,
             ros2_type,
             zenoh_key_expr_prefix,
-            zsession,
-            _config: config,
+            context: context.clone(),
             is_active: false,
             route_send_goal,
             route_cancel_goal,
@@ -157,14 +140,17 @@ impl RouteActionSrv<'_> {
         })
     }
 
-    async fn activate<'a>(&'a mut self, plugin_id: &keyexpr) -> Result<(), String> {
+    async fn activate<'a>(&'a mut self) -> Result<(), String> {
         self.is_active = true;
 
         // create associated LivelinessToken
-        let liveliness_ke =
-            new_ke_liveliness_action_srv(plugin_id, &self.zenoh_key_expr_prefix, &self.ros2_type)?;
+        let liveliness_ke = new_ke_liveliness_action_srv(
+            &self.context.plugin_id,
+            &self.zenoh_key_expr_prefix,
+            &self.ros2_type,
+        )?;
         let ros2_name = self.ros2_name.clone();
-        self.liveliness_token = Some(self.zsession
+        self.liveliness_token = Some(self.context.zsession
             .liveliness()
             .declare_token(liveliness_ke)
             .res_async()
@@ -261,24 +247,22 @@ impl RouteActionSrv<'_> {
     }
 
     #[inline]
-    pub async fn add_local_node(&mut self, node: String, plugin_id: &keyexpr) {
+    pub async fn add_local_node(&mut self, node: String) {
         futures::join!(
-            self.route_send_goal.add_local_node(node.clone(), plugin_id),
-            self.route_cancel_goal
-                .add_local_node(node.clone(), plugin_id),
-            self.route_get_result
-                .add_local_node(node.clone(), plugin_id),
+            self.route_send_goal.add_local_node(node.clone()),
+            self.route_cancel_goal.add_local_node(node.clone()),
+            self.route_get_result.add_local_node(node.clone()),
             self.route_feedback
-                .add_local_node(node.clone(), plugin_id, &QOS_ACTION_FEEDBACK),
+                .add_local_node(node.clone(), &QOS_ACTION_FEEDBACK),
             self.route_status
-                .add_local_node(node.clone(), plugin_id, &QOS_ACTION_STATUS),
+                .add_local_node(node.clone(), &QOS_ACTION_STATUS),
         );
 
         self.local_nodes.insert(node);
         log::debug!("{self} now serving local nodes {:?}", self.local_nodes);
         // if 1st local node added, activate the route
         if self.local_nodes.len() == 1 {
-            if let Err(e) = self.activate(plugin_id).await {
+            if let Err(e) = self.activate().await {
                 log::error!("{self} activation failed: {e}");
             }
         }

--- a/zenoh-plugin-ros2dds/src/route_action_srv.rs
+++ b/zenoh-plugin-ros2dds/src/route_action_srv.rs
@@ -17,8 +17,8 @@ use zenoh::{liveliness::LivelinessToken, prelude::*};
 use zenoh_core::AsyncResolve;
 
 use crate::{
-    gid::Gid, liveliness_mgt::new_ke_liveliness_action_srv, ros2_utils::*,
-    route_publisher::RoutePublisher, route_service_srv::RouteServiceSrv, routes_mgr::Context,
+    liveliness_mgt::new_ke_liveliness_action_srv, ros2_utils::*, route_publisher::RoutePublisher,
+    route_service_srv::RouteServiceSrv, routes_mgr::Context,
 };
 
 #[derive(Serialize)]
@@ -170,26 +170,6 @@ impl RouteActionSrv<'_> {
         // The DDS Writer remains to be discovered by local ROS nodes
         self.is_active = false;
         self.liveliness_token = None;
-    }
-
-    pub fn dds_writers_guids(&self) -> Result<Vec<Gid>, String> {
-        Ok([
-            self.route_send_goal.dds_req_writer_guid()?,
-            self.route_cancel_goal.dds_req_writer_guid()?,
-            self.route_get_result.dds_req_writer_guid()?,
-        ]
-        .into())
-    }
-
-    pub fn dds_readers_guids(&self) -> Result<Vec<Gid>, String> {
-        Ok([
-            self.route_send_goal.dds_rep_reader_guid()?,
-            self.route_cancel_goal.dds_rep_reader_guid()?,
-            self.route_get_result.dds_rep_reader_guid()?,
-            self.route_feedback.dds_reader_guid()?,
-            self.route_status.dds_reader_guid()?,
-        ]
-        .into())
     }
 
     #[inline]

--- a/zenoh-plugin-ros2dds/src/route_publisher.rs
+++ b/zenoh-plugin-ros2dds/src/route_publisher.rs
@@ -13,29 +13,43 @@
 //
 
 use cyclors::qos::{HistoryKind, Qos};
-use cyclors::{dds_entity_t, DDS_LENGTH_UNLIMITED};
-use serde::Serialize;
+use cyclors::DDS_LENGTH_UNLIMITED;
+use serde::{Serialize, Serializer};
+use std::ops::Deref;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 use std::{collections::HashSet, fmt};
 use zenoh::liveliness::LivelinessToken;
 use zenoh::prelude::r#async::AsyncResolve;
 use zenoh::prelude::*;
+use zenoh::publication::Publisher;
+use zenoh_core::SyncResolve;
 use zenoh_ext::{PublicationCache, SessionExt};
 
-use crate::dds_discovery::create_forwarding_dds_reader;
-use crate::dds_types::TypeInfo;
-use crate::dds_utils::{delete_dds_entity, get_guid, serialize_entity_guid};
-use crate::gid::Gid;
+use crate::dds_types::{DDSRawSample, TypeInfo};
+use crate::dds_utils::{
+    create_dds_reader, delete_dds_entity, get_guid, serialize_atomic_entity_guid, AtomicDDSEntity,
+    DDS_ENTITY_NULL,
+};
 use crate::liveliness_mgt::new_ke_liveliness_pub;
 use crate::ros2_utils::{is_message_for_action, ros2_message_type_to_dds_type};
 use crate::routes_mgr::Context;
 use crate::{qos_helpers::*, Config};
-use crate::{serialize_option_as_bool, KE_PREFIX_PUB_CACHE};
+use crate::{KE_PREFIX_PUB_CACHE, LOG_PAYLOAD};
 
-enum ZPublisher<'a> {
-    Publisher(KeyExpr<'a>),
-    PublicationCache(PublicationCache<'a>),
+pub struct ZPublisher<'a> {
+    publisher: Publisher<'static>,
+    _cache: Option<PublicationCache<'a>>,
+    cache_size: usize,
+}
+
+impl<'a> Deref for ZPublisher<'a> {
+    type Target = Publisher<'static>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.publisher
+    }
 }
 
 // a route from DDS to Zenoh
@@ -53,16 +67,25 @@ pub struct RoutePublisher<'a> {
     context: Context<'a>,
     // the zenoh publisher used to re-publish to zenoh the data received by the DDS Reader
     // `None` when route is created on a remote announcement and no local ROS2 Subscriber discovered yet
-    #[serde(rename = "is_active", serialize_with = "serialize_option_as_bool")]
-    zenoh_publisher: Option<ZPublisher<'a>>,
+    #[serde(
+        rename = "publication_cache_size",
+        serialize_with = "serialize_pub_cache"
+    )]
+    zenoh_publisher: ZPublisher<'a>,
     // the local DDS Reader created to serve the route (i.e. re-publish to zenoh data coming from DDS)
-    #[serde(serialize_with = "serialize_entity_guid")]
-    dds_reader: dds_entity_t,
-    // if the Reader is TRANSIENT_LOCAL
-    transient_local: bool,
+    #[serde(serialize_with = "serialize_atomic_entity_guid")]
+    dds_reader: AtomicDDSEntity,
+    // TypeInfo for Reader creation (if available)
+    #[serde(skip)]
+    type_info: Option<Arc<TypeInfo>>,
     // if the topic is keyless
     #[serde(skip)]
     keyless: bool,
+    // the QoS for the DDS Reader to be created.
+    // those are either the QoS announced by a remote bridge on a Reader discovery,
+    // either the QoS adapted from a local disovered Writer
+    #[serde(skip)]
+    reader_qos: Qos,
     // a liveliness token associated to this route, for announcement to other plugins
     #[serde(skip)]
     liveliness_token: Option<LivelinessToken<'a>>,
@@ -74,15 +97,7 @@ pub struct RoutePublisher<'a> {
 
 impl Drop for RoutePublisher<'_> {
     fn drop(&mut self) {
-        // remove reader's GID from ros_discovery_info message
-        match get_guid(&self.dds_reader) {
-            Ok(gid) => self.context.ros_discovery_mgr.remove_dds_reader(gid),
-            Err(e) => log::warn!("{self}: {e}"),
-        }
-
-        if let Err(e) = delete_dds_entity(self.dds_reader) {
-            log::warn!("{}: error deleting DDS Reader:  {}", self, e);
-        }
+        self.deactivate_dds_reader();
     }
 }
 
@@ -107,90 +122,20 @@ impl RoutePublisher<'_> {
         reader_qos: Qos,
         context: &Context<'a>,
     ) -> Result<RoutePublisher<'a>, String> {
-        let transient_local = is_transient_local(&reader_qos);
         log::debug!(
             "Route Publisher ({ros2_name} -> {zenoh_key_expr}): creation with type {ros2_type}"
         );
 
-        // declare the zenoh key expression (for wire optimization)
-        let declared_ke = context.zsession
-            .declare_keyexpr(zenoh_key_expr.clone())
-            .res()
-            .await
-            .map_err(|e| {
-                format!("Route Publisher ({ros2_name} -> {zenoh_key_expr}): failed to declare KeyExpr: {e}")
-            })?;
-
-        // CongestionControl to be used when re-publishing over zenoh: Blocking if Writer is RELIABLE (since we don't know what is remote Reader's QoS)
-        let congestion_ctrl = match (
-            context.config.reliable_routes_blocking,
-            is_reliable(&reader_qos),
-        ) {
-            (true, true) => CongestionControl::Block,
-            _ => CongestionControl::Drop,
-        };
-
-        let topic_name = format!("rt{ros2_name}");
-        let type_name = ros2_message_type_to_dds_type(&ros2_type);
-        let read_period = get_read_period(&context.config, &zenoh_key_expr);
-
-        // create matching DDS Reader that forwards data coming from DDS to Zenoh
-        let dds_reader = create_forwarding_dds_reader(
-            context.participant,
-            topic_name,
-            type_name,
-            type_info,
-            keyless,
-            reader_qos.clone(),
-            declared_ke.clone(),
-            context.zsession.clone(),
-            read_period,
-            congestion_ctrl,
-        )?;
-        // add reader's GID in ros_discovery_info message
-        context
-            .ros_discovery_mgr
-            .add_dds_reader(get_guid(&dds_reader)?);
-
-        Ok(RoutePublisher {
-            ros2_name,
-            ros2_type,
-            dds_reader,
-            zenoh_key_expr,
-            context: context.clone(),
-            zenoh_publisher: None,
-            transient_local,
-            keyless,
-            liveliness_token: None,
-            remote_routes: HashSet::new(),
-            local_nodes: HashSet::new(),
-        })
-    }
-
-    async fn activate<'a>(&'a mut self, discovered_writer_qos: &Qos) -> Result<(), String> {
-        // For lifetime issue, redeclare the zenoh key expression that can't be stored in Self
-        let declared_ke = self
-            .context
-            .zsession
-            .declare_keyexpr(self.zenoh_key_expr.clone())
-            .res()
-            .await
-            .map_err(|e| {
-                format!(
-                    "Route Publisher (ROS:{} -> Zenoh:{}): failed to declare KeyExpr: {e}",
-                    self.ros2_name, self.zenoh_key_expr
-                )
-            })?;
-
         // create the zenoh Publisher
-        // if Reader is TRANSIENT_LOCAL, use a PublicationCache to store historical data
-        self.zenoh_publisher = if self.transient_local {
+        // if Reader shall be TRANSIENT_LOCAL, use a PublicationCache to store historical data
+        let transient_local = is_transient_local(&reader_qos);
+        let (cache, cache_size) = if transient_local {
             #[allow(non_upper_case_globals)]
-            let history_qos = get_history_or_default(discovered_writer_qos);
-            let durability_service_qos = get_durability_service_or_default(discovered_writer_qos);
+            let history_qos = get_history_or_default(&reader_qos);
+            let durability_service_qos = get_durability_service_or_default(&reader_qos);
             let mut history = match (history_qos.kind, history_qos.depth) {
                 (HistoryKind::KEEP_LAST, n) => {
-                    if self.keyless {
+                    if keyless {
                         // only 1 instance => history=n
                         n as usize
                     } else if durability_service_qos.max_instances == DDS_LENGTH_UNLIMITED {
@@ -208,46 +153,117 @@ impl RoutePublisher<'_> {
                 (HistoryKind::KEEP_ALL, _) => usize::MAX,
             };
             // In case there are several Writers served by this route, increase the cache size
-            history = history.saturating_mul(self.context.config.transient_local_cache_multiplier);
+            history = history.saturating_mul(context.config.transient_local_cache_multiplier);
             log::debug!(
-                "{self}: caching TRANSIENT_LOCAL publications via a PublicationCache with history={history} (computed from Reader's QoS: history=({:?},{}), durability_service.max_instances={})",
+                "Route Publisher ({ros2_name} -> {zenoh_key_expr}): caching TRANSIENT_LOCAL publications via a PublicationCache with history={history} (computed from Reader's QoS: history=({:?},{}), durability_service.max_instances={})",
                 history_qos.kind, history_qos.depth, durability_service_qos.max_instances
             );
-            let pub_cache = self
-                .context
-                .zsession
-                .declare_publication_cache(&declared_ke)
-                .history(history)
-                .queryable_prefix(*KE_PREFIX_PUB_CACHE / &self.context.plugin_id)
-                .queryable_allowed_origin(Locality::Remote) // Note: don't reply to queries from local QueryingSubscribers
-                .res()
-                .await
-                .map_err(|e| {
-                    format!(
-                        "Failed create PublicationCache for key {} (rid={}): {e}",
-                        self.zenoh_key_expr, declared_ke
-                    )
-                })?;
-            Some(ZPublisher::PublicationCache(pub_cache))
+            (
+                Some(
+                    context
+                        .zsession
+                        .declare_publication_cache(&zenoh_key_expr)
+                        .history(history)
+                        .queryable_prefix(*KE_PREFIX_PUB_CACHE / &context.plugin_id)
+                        .queryable_allowed_origin(Locality::Remote) // Note: don't reply to queries from local QueryingSubscribers
+                        .res_async()
+                        .await
+                        .map_err(|e| {
+                            format!("Failed create PublicationCache for key {zenoh_key_expr}: {e}",)
+                        })?,
+                ),
+                history,
+            )
         } else {
-            if let Err(e) = self
-                .context
-                .zsession
-                .declare_publisher(declared_ke.clone())
-                .res()
-                .await
-            {
-                log::warn!(
-                    "Failed to declare publisher for key {} (rid={}): {}",
-                    self.zenoh_key_expr,
-                    declared_ke,
-                    e
-                );
-            }
-            Some(ZPublisher::Publisher(declared_ke.clone()))
+            (None, 0)
         };
 
-        // if not for an Action (since actions declare their own liveliness)
+        // CongestionControl to be used when re-publishing over zenoh: Blocking if Writer is RELIABLE (since we don't know what is remote Reader's QoS)
+        let congestion_ctrl = match (
+            context.config.reliable_routes_blocking,
+            is_reliable(&reader_qos),
+        ) {
+            (true, true) => CongestionControl::Block,
+            _ => CongestionControl::Drop,
+        };
+
+        let publisher: Publisher<'static> = context
+            .zsession
+            .declare_publisher(zenoh_key_expr.clone())
+            .congestion_control(congestion_ctrl)
+            .res_async()
+            .await
+            .map_err(|e| format!("Failed create Publisher for key {zenoh_key_expr}: {e}",))?;
+
+        Ok(RoutePublisher {
+            ros2_name,
+            ros2_type,
+            zenoh_key_expr,
+            context: context.clone(),
+            zenoh_publisher: ZPublisher {
+                publisher,
+                _cache: cache,
+                cache_size,
+            },
+            dds_reader: DDS_ENTITY_NULL.into(),
+            type_info: type_info.clone(),
+            reader_qos,
+            keyless,
+            liveliness_token: None,
+            remote_routes: HashSet::new(),
+            local_nodes: HashSet::new(),
+        })
+    }
+
+    fn activate_dds_reader(&mut self) -> Result<(), String> {
+        let topic_name = format!("rt{}", self.ros2_name);
+        let type_name = ros2_message_type_to_dds_type(&self.ros2_type);
+        let read_period = get_read_period(&self.context.config, &self.zenoh_key_expr);
+        let route_id = self.to_string();
+        let publisher = self.zenoh_publisher.deref().clone();
+
+        // create matching DDS Reader that forwards data coming from DDS to Zenoh
+        let dds_reader = create_dds_reader(
+            self.context.participant,
+            topic_name,
+            type_name,
+            &self.type_info,
+            self.keyless,
+            self.reader_qos.clone(),
+            read_period,
+            move |sample: &DDSRawSample| {
+                do_route_message(
+                    sample, &publisher, // &ke,
+                    &route_id,
+                );
+            },
+        )?;
+        self.dds_reader.swap(dds_reader, Ordering::Relaxed);
+
+        // add reader's GID in ros_discovery_info message
+        self.context
+            .ros_discovery_mgr
+            .add_dds_reader(get_guid(&dds_reader)?);
+
+        Ok(())
+    }
+
+    fn deactivate_dds_reader(&mut self) {
+        let dds_reader = self.dds_reader.swap(DDS_ENTITY_NULL, Ordering::Relaxed);
+        if dds_reader != DDS_ENTITY_NULL {
+            // remove reader's GID from ros_discovery_info message
+            match get_guid(&dds_reader) {
+                Ok(gid) => self.context.ros_discovery_mgr.remove_dds_reader(gid),
+                Err(e) => log::warn!("{self}: {e}"),
+            }
+            if let Err(e) = delete_dds_entity(dds_reader) {
+                log::warn!("{}: error deleting DDS Reader:  {}", self, e);
+            }
+        }
+    }
+
+    async fn announce_route(&mut self, discovered_writer_qos: &Qos) -> Result<(), String> {
+        // only if not for an Action (since actions declare their own liveliness)
         if !is_message_for_action(&self.ros2_name) {
             // create associated LivelinessToken
             let liveliness_ke = new_ke_liveliness_pub(
@@ -261,7 +277,7 @@ impl RoutePublisher<'_> {
             self.liveliness_token = Some(self.context.zsession
                 .liveliness()
                 .declare_token(liveliness_ke)
-                .res()
+                .res_async()
                 .await
                 .map_err(|e| {
                     format!(
@@ -273,17 +289,8 @@ impl RoutePublisher<'_> {
         Ok(())
     }
 
-    fn deactivate(&mut self) {
-        log::debug!("{self} deactivate");
-        // Drop Zenoh Publisher and Liveliness token
-        // The DDS Writer remains to be discovered by local ROS nodes
-        self.zenoh_publisher = None;
+    fn retire_route(&mut self) {
         self.liveliness_token = None;
-    }
-
-    #[inline]
-    pub fn dds_reader_guid(&self) -> Result<Gid, String> {
-        get_guid(&self.dds_reader)
     }
 
     #[inline]
@@ -291,6 +298,12 @@ impl RoutePublisher<'_> {
         self.remote_routes
             .insert(format!("{plugin_id}:{zenoh_key_expr}"));
         log::debug!("{self} now serving remote routes {:?}", self.remote_routes);
+        // if 1st remote route added, activate the DDS Reader
+        if self.remote_routes.len() == 1 {
+            if let Err(e) = self.activate_dds_reader() {
+                log::error!("{self} activation of DDS Reader failed: {e}");
+            }
+        }
     }
 
     #[inline]
@@ -298,6 +311,10 @@ impl RoutePublisher<'_> {
         self.remote_routes
             .remove(&format!("{plugin_id}:{zenoh_key_expr}"));
         log::debug!("{self} now serving remote routes {:?}", self.remote_routes);
+        // if last remote route removed, deactivate the DDS Reader
+        if self.remote_routes.is_empty() {
+            self.deactivate_dds_reader();
+        }
     }
 
     #[inline]
@@ -309,10 +326,10 @@ impl RoutePublisher<'_> {
     pub async fn add_local_node(&mut self, node: String, discovered_writer_qos: &Qos) {
         self.local_nodes.insert(node);
         log::debug!("{self} now serving local nodes {:?}", self.local_nodes);
-        // if 1st local node added, activate the route
+        // if 1st local node added, announce the route
         if self.local_nodes.len() == 1 {
-            if let Err(e) = self.activate(discovered_writer_qos).await {
-                log::error!("{self} activation failed: {e}");
+            if let Err(e) = self.announce_route(discovered_writer_qos).await {
+                log::error!("{self} announcement failed: {e}");
             }
         }
     }
@@ -321,9 +338,9 @@ impl RoutePublisher<'_> {
     pub fn remove_local_node(&mut self, node: &str) {
         self.local_nodes.remove(node);
         log::debug!("{self} now serving local nodes {:?}", self.local_nodes);
-        // if last local node removed, deactivate the route
+        // if last local node removed, retire the route
         if self.local_nodes.is_empty() {
-            self.deactivate();
+            self.retire_route();
         }
     }
 
@@ -338,6 +355,13 @@ impl RoutePublisher<'_> {
     }
 }
 
+pub fn serialize_pub_cache<S>(zpub: &ZPublisher, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    s.serialize_u64(zpub.cache_size as u64)
+}
+
 // Return the read period if keyexpr matches one of the "pub_max_frequencies" option
 fn get_read_period(config: &Config, ke: &keyexpr) -> Option<Duration> {
     for (re, freq) in &config.pub_max_frequencies {
@@ -346,4 +370,15 @@ fn get_read_period(config: &Config, ke: &keyexpr) -> Option<Duration> {
         }
     }
     None
+}
+
+fn do_route_message(sample: &DDSRawSample, publisher: &Publisher, route_id: &str) {
+    if *LOG_PAYLOAD {
+        log::trace!("{route_id}: routing message - payload: {:02x?}", sample);
+    } else {
+        log::trace!("{route_id}: routing message - {} bytes", sample.len());
+    }
+    if let Err(e) = publisher.put(sample).res_sync() {
+        log::error!("{route_id}: failed to route message: {e}");
+    }
 }

--- a/zenoh-plugin-ros2dds/src/route_service_cli.rs
+++ b/zenoh-plugin-ros2dds/src/route_service_cli.rs
@@ -29,7 +29,6 @@ use crate::dds_utils::serialize_entity_guid;
 use crate::dds_utils::{
     create_dds_reader, create_dds_writer, dds_write, delete_dds_entity, get_guid,
 };
-use crate::gid::Gid;
 use crate::liveliness_mgt::new_ke_liveliness_service_cli;
 use crate::ros2_utils::{
     is_service_for_action, new_service_id, ros2_service_type_to_reply_dds_type,
@@ -220,14 +219,6 @@ impl RouteServiceCli<'_> {
         // The DDS Writer remains to be discovered by local ROS nodes
         self.is_active = false;
         self.liveliness_token = None;
-    }
-
-    pub fn dds_rep_writer_guid(&self) -> Result<Gid, String> {
-        get_guid(&self.rep_writer)
-    }
-
-    pub fn dds_req_reader_guid(&self) -> Result<Gid, String> {
-        get_guid(&self.req_reader)
     }
 
     #[inline]

--- a/zenoh-plugin-ros2dds/src/route_service_srv.rs
+++ b/zenoh-plugin-ros2dds/src/route_service_srv.rs
@@ -33,7 +33,6 @@ use crate::dds_utils::{
     create_dds_reader, create_dds_writer, dds_write, delete_dds_entity, get_guid,
     get_instance_handle,
 };
-use crate::gid::Gid;
 use crate::liveliness_mgt::new_ke_liveliness_service_srv;
 use crate::ros2_utils::{
     is_service_for_action, new_service_id, ros2_service_type_to_reply_dds_type,
@@ -293,14 +292,6 @@ impl RouteServiceSrv<'_> {
         // The DDS Writer remains to be discovered by local ROS nodes
         self.zenoh_queryable = None;
         self.liveliness_token = None;
-    }
-
-    pub fn dds_req_writer_guid(&self) -> Result<Gid, String> {
-        get_guid(&self.req_writer)
-    }
-
-    pub fn dds_rep_reader_guid(&self) -> Result<Gid, String> {
-        get_guid(&self.rep_reader)
     }
 
     #[inline]

--- a/zenoh-plugin-ros2dds/src/route_subscriber.rs
+++ b/zenoh-plugin-ros2dds/src/route_subscriber.rs
@@ -27,7 +27,6 @@ use zenoh::{prelude::r#async::AsyncResolve, subscriber::Subscriber};
 use zenoh_ext::{FetchingSubscriber, SubscriberBuilderExt};
 
 use crate::dds_utils::{create_dds_writer, delete_dds_entity, get_guid};
-use crate::gid::Gid;
 use crate::liveliness_mgt::new_ke_liveliness_sub;
 use crate::qos_helpers::is_transient_local;
 use crate::ros2_utils::{is_message_for_action, ros2_message_type_to_dds_type};
@@ -265,11 +264,6 @@ impl RouteSubscriber<'_> {
                 );
             }
         }
-    }
-
-    #[inline]
-    pub fn dds_writer_guid(&self) -> Result<Gid, String> {
-        get_guid(&self.dds_writer)
     }
 
     #[inline]

--- a/zenoh-plugin-ros2dds/src/route_subscriber.rs
+++ b/zenoh-plugin-ros2dds/src/route_subscriber.rs
@@ -19,7 +19,6 @@ use cyclors::{
 use serde::Serialize;
 use std::collections::HashSet;
 use std::convert::TryInto;
-use std::sync::Arc;
 use std::{ffi::CStr, fmt, time::Duration};
 use zenoh::liveliness::LivelinessToken;
 use zenoh::prelude::*;
@@ -32,9 +31,9 @@ use crate::gid::Gid;
 use crate::liveliness_mgt::new_ke_liveliness_sub;
 use crate::qos_helpers::is_transient_local;
 use crate::ros2_utils::{is_message_for_action, ros2_message_type_to_dds_type};
+use crate::routes_mgr::Context;
 use crate::{
-    dds_utils::serialize_entity_guid, qos::Qos, vec_into_raw_parts, Config, KE_ANY_1_SEGMENT,
-    LOG_PAYLOAD,
+    dds_utils::serialize_entity_guid, qos::Qos, vec_into_raw_parts, KE_ANY_1_SEGMENT, LOG_PAYLOAD,
 };
 use crate::{serialize_option_as_bool, KE_PREFIX_PUB_CACHE};
 
@@ -53,12 +52,9 @@ pub struct RouteSubscriber<'a> {
     ros2_type: String,
     // the Zenoh key expression used for routing
     zenoh_key_expr: OwnedKeyExpr,
-    // the zenoh session
+    // the context
     #[serde(skip)]
-    zsession: &'a Arc<Session>,
-    // the config
-    #[serde(skip)]
-    config: Arc<Config>,
+    context: Context<'a>,
     // the zenoh subscriber receiving data to be re-published by the DDS Writer
     // `None` when route is created on a remote announcement and no local ROS2 Subscriber discovered yet
     #[serde(rename = "is_active", serialize_with = "serialize_option_as_bool")]
@@ -100,31 +96,33 @@ impl fmt::Display for RouteSubscriber<'_> {
 
 impl RouteSubscriber<'_> {
     #[allow(clippy::too_many_arguments)]
-    pub async fn create<'b>(
-        config: Arc<Config>,
-        zsession: &Arc<Session>,
-        participant: dds_entity_t,
+    pub async fn create<'a>(
         ros2_name: String,
         ros2_type: String,
         zenoh_key_expr: OwnedKeyExpr,
         keyless: bool,
         writer_qos: Qos,
-    ) -> Result<RouteSubscriber<'_>, String> {
+        context: &Context<'a>,
+    ) -> Result<RouteSubscriber<'a>, String> {
         let transient_local = is_transient_local(&writer_qos);
         log::debug!("Route Subscriber ({zenoh_key_expr} -> {ros2_name}): creation with type {ros2_type} (transient_local:{transient_local})");
 
         let topic_name = format!("rt{ros2_name}");
         let type_name = ros2_message_type_to_dds_type(&ros2_type);
 
-        let dds_writer =
-            create_dds_writer(participant, topic_name, type_name, keyless, writer_qos)?;
+        let dds_writer = create_dds_writer(
+            context.participant,
+            topic_name,
+            type_name,
+            keyless,
+            writer_qos,
+        )?;
 
         Ok(RouteSubscriber {
             ros2_name,
             ros2_type,
             zenoh_key_expr,
-            zsession,
-            config: config,
+            context: context.clone(),
             zenoh_subscriber: None,
             dds_writer,
             transient_local,
@@ -135,11 +133,7 @@ impl RouteSubscriber<'_> {
         })
     }
 
-    async fn activate(
-        &mut self,
-        plugin_id: &keyexpr,
-        discovered_reader_qos: &Qos,
-    ) -> Result<(), String> {
+    async fn activate(&mut self, discovered_reader_qos: &Qos) -> Result<(), String> {
         log::debug!("{self} activate");
         // Callback routing data received by Zenoh subscriber to DDS Writer (if set)
         let ros2_name = self.ros2_name.clone();
@@ -156,13 +150,14 @@ impl RouteSubscriber<'_> {
                 (*KE_PREFIX_PUB_CACHE / *KE_ANY_1_SEGMENT / &self.zenoh_key_expr).into();
             log::debug!("{self}: query historical data from everybody for TRANSIENT_LOCAL Reader on {query_selector}");
             let sub = self
+                .context
                 .zsession
                 .declare_subscriber(&self.zenoh_key_expr)
                 .callback(subscriber_callback)
                 .allowed_origin(Locality::Remote) // Allow only remote publications to avoid loops
                 .reliable()
                 .querying()
-                .query_timeout(self.config.queries_timeout)
+                .query_timeout(self.context.config.queries_timeout)
                 .query_selector(query_selector)
                 .query_accept_replies(ReplyKeyExpr::Any)
                 .res()
@@ -171,6 +166,7 @@ impl RouteSubscriber<'_> {
             Some(ZSubscriber::FetchingSubscriber(sub))
         } else {
             let sub = self
+                .context
                 .zsession
                 .declare_subscriber(&self.zenoh_key_expr)
                 .callback(subscriber_callback)
@@ -186,7 +182,7 @@ impl RouteSubscriber<'_> {
         if !is_message_for_action(&self.ros2_name) {
             // create associated LivelinessToken
             let liveliness_ke = new_ke_liveliness_sub(
-                plugin_id,
+                &self.context.plugin_id,
                 &self.zenoh_key_expr,
                 &self.ros2_type,
                 self.keyless,
@@ -194,7 +190,7 @@ impl RouteSubscriber<'_> {
             )?;
             let ros2_name = self.ros2_name.clone();
             self.liveliness_token = Some(
-                self.zsession
+                self.context.zsession
                     .liveliness()
                     .declare_token(liveliness_ke)
                     .res()
@@ -234,7 +230,7 @@ impl RouteSubscriber<'_> {
 
             if let Err(e) = sub
                 .fetch({
-                    let session = &self.zsession;
+                    let session = &self.context.zsession;
                     let query_selector = query_selector.clone();
                     move |cb| {
                         use zenoh_core::SyncResolve;
@@ -286,17 +282,12 @@ impl RouteSubscriber<'_> {
     }
 
     #[inline]
-    pub async fn add_local_node(
-        &mut self,
-        entity_key: String,
-        plugin_id: &keyexpr,
-        discovered_reader_qos: &Qos,
-    ) {
+    pub async fn add_local_node(&mut self, entity_key: String, discovered_reader_qos: &Qos) {
         self.local_nodes.insert(entity_key);
         log::debug!("{self} now serving local nodes {:?}", self.local_nodes);
         // if 1st local node added, activate the route
         if self.local_nodes.len() == 1 {
-            if let Err(e) = self.activate(plugin_id, discovered_reader_qos).await {
+            if let Err(e) = self.activate(discovered_reader_qos).await {
                 log::error!("{self} activation failed: {e}");
             }
         }

--- a/zenoh-plugin-ros2dds/src/routes_mgr.rs
+++ b/zenoh-plugin-ros2dds/src/routes_mgr.rs
@@ -542,13 +542,6 @@ impl<'a> RoutesMgr<'a> {
                 .await?;
                 log::info!("{route} created");
 
-                // insert reader's GID in ros_discovery_msg
-                self.context
-                    .ros_discovery_mgr
-                    .add_dds_reader(route.dds_reader_guid().map_err(|e| {
-                        format!("{route}: failed to update ros_discovery_info message: {e}")
-                    })?);
-
                 if admin_space_ref {
                     // insert reference in admin_space
                     let admin_ke = *KE_PREFIX_ROUTE_PUBLISHER / zenoh_key_expr;
@@ -585,13 +578,6 @@ impl<'a> RoutesMgr<'a> {
                 )
                 .await?;
                 log::info!("{route} created");
-
-                // insert writer's GID in ros_discovery_msg
-                self.context
-                    .ros_discovery_mgr
-                    .add_dds_writer(route.dds_writer_guid().map_err(|e| {
-                        format!("{route}: failed to update ros_discovery_info message: {e}")
-                    })?);
 
                 if admin_space_ref {
                     // insert reference in admin_space
@@ -693,18 +679,6 @@ impl<'a> RoutesMgr<'a> {
                 .await?;
                 log::info!("{route} created");
 
-                // insert readers' and writes' GID in ros_discovery_msg
-                self.context
-                    .ros_discovery_mgr
-                    .add_dds_readers(route.dds_readers_guids().map_err(|e| {
-                        format!("{route}: failed to update ros_discovery_info message: {e}")
-                    })?);
-                self.context
-                    .ros_discovery_mgr
-                    .add_dds_writers(route.dds_writers_guids().map_err(|e| {
-                        format!("{route}: failed to update ros_discovery_info message: {e}")
-                    })?);
-
                 // insert reference in admin_space
                 let admin_ke = *KE_PREFIX_ROUTE_ACTION_SRV / zenoh_key_expr;
                 self.admin_space
@@ -734,18 +708,6 @@ impl<'a> RoutesMgr<'a> {
                 )
                 .await?;
                 log::info!("{route} created");
-
-                // insert readers' and writes' GID in ros_discovery_msg
-                self.context
-                    .ros_discovery_mgr
-                    .add_dds_readers(route.dds_readers_guids().map_err(|e| {
-                        format!("{route}: failed to update ros_discovery_info message: {e}")
-                    })?);
-                self.context
-                    .ros_discovery_mgr
-                    .add_dds_writers(route.dds_writers_guids().map_err(|e| {
-                        format!("{route}: failed to update ros_discovery_info message: {e}")
-                    })?);
 
                 // insert reference in admin_space
                 let admin_ke = *KE_PREFIX_ROUTE_ACTION_CLI / zenoh_key_expr;

--- a/zenoh-plugin-ros2dds/src/routes_mgr.rs
+++ b/zenoh-plugin-ros2dds/src/routes_mgr.rs
@@ -168,12 +168,6 @@ impl<'a> RoutesMgr<'a> {
                         self.admin_space
                             .remove(&(*KE_PREFIX_ROUTE_PUBLISHER / iface.name_as_keyexpr()));
                         let route = entry.remove();
-                        // remove reader's GID in ros_discovery_msg
-                        self.context.ros_discovery_mgr.remove_dds_reader(
-                            route.dds_reader_guid().map_err(|e| {
-                                format!("{route}: failed to update ros_discovery_info message: {e}")
-                            })?,
-                        );
                         log::info!("{route} removed");
                     }
                 }
@@ -214,12 +208,6 @@ impl<'a> RoutesMgr<'a> {
                         self.admin_space
                             .remove(&(*KE_PREFIX_ROUTE_SUBSCRIBER / iface.name_as_keyexpr()));
                         let route = entry.remove();
-                        // remove writer's GID in ros_discovery_msg
-                        self.context.ros_discovery_mgr.remove_dds_writer(
-                            route.dds_writer_guid().map_err(|e| {
-                                format!("{route}: failed to update ros_discovery_info message: {e}")
-                            })?,
-                        );
                         log::info!("{route} removed");
                     }
                 }
@@ -241,17 +229,6 @@ impl<'a> RoutesMgr<'a> {
                         self.admin_space
                             .remove(&(*KE_PREFIX_ROUTE_SERVICE_SRV / iface.name_as_keyexpr()));
                         let route = entry.remove();
-                        // remove reader's and writer's GID in ros_discovery_msg
-                        self.context.ros_discovery_mgr.remove_dds_reader(
-                            route.dds_rep_reader_guid().map_err(|e| {
-                                format!("{route}: failed to update ros_discovery_info message: {e}")
-                            })?,
-                        );
-                        self.context.ros_discovery_mgr.remove_dds_writer(
-                            route.dds_req_writer_guid().map_err(|e| {
-                                format!("{route}: failed to update ros_discovery_info message: {e}")
-                            })?,
-                        );
                         log::info!("{route} removed");
                     }
                 }
@@ -273,17 +250,6 @@ impl<'a> RoutesMgr<'a> {
                         self.admin_space
                             .remove(&(*KE_PREFIX_ROUTE_SERVICE_CLI / iface.name_as_keyexpr()));
                         let route = entry.remove();
-                        // remove reader's and writer's GID in ros_discovery_msg
-                        self.context.ros_discovery_mgr.remove_dds_reader(
-                            route.dds_req_reader_guid().map_err(|e| {
-                                format!("{route}: failed to update ros_discovery_info message: {e}")
-                            })?,
-                        );
-                        self.context.ros_discovery_mgr.remove_dds_writer(
-                            route.dds_rep_writer_guid().map_err(|e| {
-                                format!("{route}: failed to update ros_discovery_info message: {e}")
-                            })?,
-                        );
                         log::info!("{route} removed");
                     }
                 }
@@ -304,17 +270,6 @@ impl<'a> RoutesMgr<'a> {
                         self.admin_space
                             .remove(&(*KE_PREFIX_ROUTE_ACTION_SRV / iface.name_as_keyexpr()));
                         let route = entry.remove();
-                        // remove reader's and writer's GID in ros_discovery_msg
-                        self.context.ros_discovery_mgr.remove_dds_readers(
-                            route.dds_readers_guids().map_err(|e| {
-                                format!("{route}: failed to update ros_discovery_info message: {e}")
-                            })?,
-                        );
-                        self.context.ros_discovery_mgr.remove_dds_writers(
-                            route.dds_writers_guids().map_err(|e| {
-                                format!("{route}: failed to update ros_discovery_info message: {e}")
-                            })?,
-                        );
                         log::info!("{route} removed");
                     }
                 }
@@ -335,17 +290,6 @@ impl<'a> RoutesMgr<'a> {
                         self.admin_space
                             .remove(&(*KE_PREFIX_ROUTE_ACTION_CLI / iface.name_as_keyexpr()));
                         let route = entry.remove();
-                        // remove reader's and writer's GID in ros_discovery_msg
-                        self.context.ros_discovery_mgr.remove_dds_readers(
-                            route.dds_readers_guids().map_err(|e| {
-                                format!("{route}: failed to update ros_discovery_info message: {e}")
-                            })?,
-                        );
-                        self.context.ros_discovery_mgr.remove_dds_writers(
-                            route.dds_writers_guids().map_err(|e| {
-                                format!("{route}: failed to update ros_discovery_info message: {e}")
-                            })?,
-                        );
                         log::info!("{route} removed");
                     }
                 }
@@ -394,12 +338,6 @@ impl<'a> RoutesMgr<'a> {
                         self.admin_space
                             .remove(&(*KE_PREFIX_ROUTE_SUBSCRIBER / &zenoh_key_expr));
                         let route = entry.remove();
-                        // remove writer's GID in ros_discovery_msg
-                        self.context.ros_discovery_mgr.remove_dds_writer(
-                            route.dds_writer_guid().map_err(|e| {
-                                format!("{route}: failed to update ros_discovery_info message: {e}")
-                            })?,
-                        );
                         log::info!("{route} removed");
                     }
                 }
@@ -439,12 +377,6 @@ impl<'a> RoutesMgr<'a> {
                         self.admin_space
                             .remove(&(*KE_PREFIX_ROUTE_PUBLISHER / &zenoh_key_expr));
                         let route = entry.remove();
-                        // remove reader's GID in ros_discovery_msg
-                        self.context.ros_discovery_mgr.remove_dds_reader(
-                            route.dds_reader_guid().map_err(|e| {
-                                format!("{route}: failed to update ros_discovery_info message: {e}")
-                            })?,
-                        );
                         log::info!("{route} removed");
                     }
                 }
@@ -476,17 +408,6 @@ impl<'a> RoutesMgr<'a> {
                         self.admin_space
                             .remove(&(*KE_PREFIX_ROUTE_SERVICE_CLI / &zenoh_key_expr));
                         let route = entry.remove();
-                        // remove reader's and writer's GID in ros_discovery_msg
-                        self.context.ros_discovery_mgr.remove_dds_reader(
-                            route.dds_req_reader_guid().map_err(|e| {
-                                format!("{route}: failed to update ros_discovery_info message: {e}")
-                            })?,
-                        );
-                        self.context.ros_discovery_mgr.remove_dds_writer(
-                            route.dds_rep_writer_guid().map_err(|e| {
-                                format!("{route}: failed to update ros_discovery_info message: {e}")
-                            })?,
-                        );
                         log::info!("{route} removed");
                     }
                 }
@@ -518,17 +439,6 @@ impl<'a> RoutesMgr<'a> {
                         self.admin_space
                             .remove(&(*KE_PREFIX_ROUTE_SERVICE_SRV / &zenoh_key_expr));
                         let route = entry.remove();
-                        // remove reader's and writer's GID in ros_discovery_msg
-                        self.context.ros_discovery_mgr.remove_dds_reader(
-                            route.dds_rep_reader_guid().map_err(|e| {
-                                format!("{route}: failed to update ros_discovery_info message: {e}")
-                            })?,
-                        );
-                        self.context.ros_discovery_mgr.remove_dds_writer(
-                            route.dds_req_writer_guid().map_err(|e| {
-                                format!("{route}: failed to update ros_discovery_info message: {e}")
-                            })?,
-                        );
                         log::info!("{route} removed");
                     }
                 }
@@ -560,17 +470,6 @@ impl<'a> RoutesMgr<'a> {
                         self.admin_space
                             .remove(&(*KE_PREFIX_ROUTE_SERVICE_CLI / &zenoh_key_expr));
                         let route = entry.remove();
-                        // remove reader's and writer's GID in ros_discovery_msg
-                        self.context.ros_discovery_mgr.remove_dds_readers(
-                            route.dds_readers_guids().map_err(|e| {
-                                format!("{route}: failed to update ros_discovery_info message: {e}")
-                            })?,
-                        );
-                        self.context.ros_discovery_mgr.remove_dds_writers(
-                            route.dds_writers_guids().map_err(|e| {
-                                format!("{route}: failed to update ros_discovery_info message: {e}")
-                            })?,
-                        );
                         log::info!("{route} removed");
                     }
                 }
@@ -602,17 +501,6 @@ impl<'a> RoutesMgr<'a> {
                         self.admin_space
                             .remove(&(*KE_PREFIX_ROUTE_SERVICE_SRV / &zenoh_key_expr));
                         let route = entry.remove();
-                        // remove reader's and writer's GID in ros_discovery_msg
-                        self.context.ros_discovery_mgr.remove_dds_readers(
-                            route.dds_readers_guids().map_err(|e| {
-                                format!("{route}: failed to update ros_discovery_info message: {e}")
-                            })?,
-                        );
-                        self.context.ros_discovery_mgr.remove_dds_writers(
-                            route.dds_writers_guids().map_err(|e| {
-                                format!("{route}: failed to update ros_discovery_info message: {e}")
-                            })?,
-                        );
                         log::info!("{route} removed");
                     }
                 }
@@ -739,18 +627,6 @@ impl<'a> RoutesMgr<'a> {
                 .await?;
                 log::info!("{route} created");
 
-                // insert reader's and writer's GID in ros_discovery_msg
-                self.context.ros_discovery_mgr.add_dds_reader(
-                    route.dds_rep_reader_guid().map_err(|e| {
-                        format!("{route}: failed to update ros_discovery_info message: {e}")
-                    })?,
-                );
-                self.context.ros_discovery_mgr.add_dds_writer(
-                    route.dds_req_writer_guid().map_err(|e| {
-                        format!("{route}: failed to update ros_discovery_info message: {e}")
-                    })?,
-                );
-
                 if admin_space_ref {
                     // insert reference in admin_space
                     let admin_ke = *KE_PREFIX_ROUTE_SERVICE_SRV / zenoh_key_expr;
@@ -784,18 +660,6 @@ impl<'a> RoutesMgr<'a> {
                 )
                 .await?;
                 log::info!("{route} created");
-
-                // insert reader's and writer's GID in ros_discovery_msg
-                self.context.ros_discovery_mgr.add_dds_reader(
-                    route.dds_req_reader_guid().map_err(|e| {
-                        format!("{route}: failed to update ros_discovery_info message: {e}")
-                    })?,
-                );
-                self.context.ros_discovery_mgr.add_dds_writer(
-                    route.dds_rep_writer_guid().map_err(|e| {
-                        format!("{route}: failed to update ros_discovery_info message: {e}")
-                    })?,
-                );
 
                 if admin_space_ref {
                     // insert reference in admin_space


### PR DESCRIPTION
Change bridge behaviour for Publishers routes:
the DDS Reader is not directly created, but only when a remote bridge announces a Subscriber route.

This avoids possible overwhelming and unnecessary traffic to the bridge as soon as it starts.