### PR TITLE
Fix matching subscriptions to consider only remote ones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4054,7 +4054,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "async-global-executor",
  "async-std",
@@ -4118,7 +4118,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "zenoh-collections",
 ]
@@ -4126,7 +4126,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "log",
  "serde",
@@ -4138,12 +4138,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 
 [[package]]
 name = "zenoh-config"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "flume",
  "json5",
@@ -4161,7 +4161,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "async-std",
  "lazy_static",
@@ -4171,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "aes 0.8.3",
  "hmac 0.12.1",
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "async-std",
  "bincode",
@@ -4204,7 +4204,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "hashbrown 0.14.0",
  "keyed-set",
@@ -4218,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "async-std",
  "async-trait",
@@ -4237,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "async-std",
  "async-trait",
@@ -4253,7 +4253,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -4277,7 +4277,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "async-std",
  "async-trait",
@@ -4293,7 +4293,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -4316,7 +4316,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "async-std",
  "async-trait",
@@ -4335,7 +4335,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "async-std",
  "async-trait",
@@ -4353,7 +4353,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "async-std",
  "async-trait",
@@ -4373,7 +4373,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4386,7 +4386,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-rest"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "anyhow",
  "async-std",
@@ -4443,7 +4443,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "libloading 0.8.0",
  "log",
@@ -4456,7 +4456,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "const_format",
  "hex",
@@ -4472,7 +4472,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "anyhow",
 ]
@@ -4480,7 +4480,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "async-std",
  "event-listener",
@@ -4495,7 +4495,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "async-executor",
  "async-global-executor",
@@ -4526,7 +4526,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#f23bce57d6c7cc1fa0e6d5b5715cca72158e8812"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=matching_state#819f53e9685978167d63fbc750c3d6b8400691a5"
 dependencies = [
  "async-std",
  "async-trait",

--- a/zenoh-plugin-ros2dds/src/route_publisher.rs
+++ b/zenoh-plugin-ros2dds/src/route_publisher.rs
@@ -199,6 +199,7 @@ impl RoutePublisher<'_> {
         let publisher: Arc<Publisher<'static>> = context
             .zsession
             .declare_publisher(zenoh_key_expr.clone())
+            .allowed_destination(Locality::Remote)
             .congestion_control(congestion_ctrl)
             .res_async()
             .await
@@ -508,7 +509,7 @@ fn deactivate_dds_reader(
 
 fn do_route_message(sample: &DDSRawSample, publisher: &Arc<Publisher>, route_id: &str) {
     if *LOG_PAYLOAD {
-        log::trace!("{route_id}: routing message - payload: {:02x?}", sample);
+        log::debug!("{route_id}: routing message - payload: {:02x?}", sample);
     } else {
         log::trace!("{route_id}: routing message - {} bytes", sample.len());
     }

--- a/zenoh-plugin-ros2dds/src/route_service_cli.rs
+++ b/zenoh-plugin-ros2dds/src/route_service_cli.rs
@@ -291,7 +291,7 @@ fn do_route_request(
     zenoh_req_buf.push_zslice(slice.subslice(20, slice.len()).unwrap());
 
     if *LOG_PAYLOAD {
-        log::trace!("{route_id}: routing request {request_id:02x?} to Zenoh - payload: {zenoh_req_buf:02x?}");
+        log::debug!("{route_id}: routing request {request_id:02x?} to Zenoh - payload: {zenoh_req_buf:02x?}");
     } else {
         log::trace!(
             "{route_id}: routing request {request_id:02x?} to Zenoh - {} bytes",
@@ -330,7 +330,7 @@ fn do_route_reply(route_id: String, reply: Reply, request_id: [u8; 16], rep_writ
             dds_rep_buf.extend_from_slice(&zenoh_rep_buf[4..]);
 
             if *LOG_PAYLOAD {
-                log::trace!("{route_id}: routing reply for {request_id:02x?} to Client - payload: {dds_rep_buf:02x?}");
+                log::debug!("{route_id}: routing reply for {request_id:02x?} to Client - payload: {dds_rep_buf:02x?}");
             } else {
                 log::trace!(
                     "{route_id}: routing reply for {request_id:02x?} to Client - {} bytes",

--- a/zenoh-plugin-ros2dds/src/route_service_srv.rs
+++ b/zenoh-plugin-ros2dds/src/route_service_srv.rs
@@ -388,7 +388,7 @@ fn do_route_request(
     };
 
     if *LOG_PAYLOAD {
-        log::trace!("{route_id}: routing request #{n} to Service - payload: {dds_req_buf:02x?}");
+        log::debug!("{route_id}: routing request #{n} to Service - payload: {dds_req_buf:02x?}");
     } else {
         log::trace!(
             "{route_id}: routing request #{n} to Service - {} bytes",
@@ -448,7 +448,7 @@ fn do_route_reply(
             zenoh_rep_buf.push_zslice(slice.subslice(20, slice.len()).unwrap());
 
             if *LOG_PAYLOAD {
-                log::trace!("{route_id}: routing reply #{seq_num} to Client - payload: {zenoh_rep_buf:02x?}");
+                log::debug!("{route_id}: routing reply #{seq_num} to Client - payload: {zenoh_rep_buf:02x?}");
             } else {
                 log::trace!(
                     "{route_id}: routing reply #{seq_num} to Client - {} bytes",

--- a/zenoh-plugin-ros2dds/src/route_subscriber.rs
+++ b/zenoh-plugin-ros2dds/src/route_subscriber.rs
@@ -319,7 +319,7 @@ impl RouteSubscriber<'_> {
 
 fn do_route_data(s: Sample, ros2_name: &str, data_writer: dds_entity_t) {
     if *LOG_PAYLOAD {
-        log::trace!(
+        log::debug!(
             "Route Subscriber (Zenoh:{} -> ROS:{}): routing data - payload: {:02x?}",
             s.key_expr,
             &ros2_name,


### PR DESCRIPTION
This improves #7 making the Route for Publisher to create a DDS Reader only when **remote** Subcriber is detected, not a local one.