### PR TITLE
Add namespace config

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -18,16 +18,20 @@
       // id: "robot-1",
 
       ////
-      //// namespace: A ROS namespace to be used by this bridge.
-      ////            Default: "/"
-      ////
-      // namespace: "/",
-
-      ////
       //// nodename: A ROS node name to be used by this bridge.
       ////            Default: "zenoh_bridge_ros2dds"
       ////
       // nodename: "zenoh_bridge_ros2dds",
+
+      ////
+      //// namespace: A ROS namespace which:
+      ////             - is used for the "zenoh_bridge_ros2dds" node itself
+      ////             - is added to all discovered interfaces when routed to Zenoh
+      ////               (i.e. a "cmd_vel" topic in the robot will be seen as "namespace/cmd_vel" outside the robot)
+      ////               Note that this also applies to topics with absolute path such as "/rosout", "/tf" and "/tf_static".
+      ////            Default: "/"
+      ////
+      // namespace: "/",
 
       ////
       //// domain: The DDS Domain ID. By default set to 0, or to "$ROS_DOMAIN_ID" is this environment variable is defined.

--- a/zenoh-plugin-ros2dds/src/ros_discovery.rs
+++ b/zenoh-plugin-ros2dds/src/ros_discovery.rs
@@ -398,7 +398,7 @@ impl std::fmt::Debug for NodeEntitiesInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(
             f,
-            "Node {}/{} :",
+            "Node namespace={} / name={} :",
             if &self.node_namespace == "/" {
                 ""
             } else {


### PR DESCRIPTION
The bridge has a `namespace` configuration that was only used as namespace for the `zenoh_bridge_ros2dds` node.

This PR prefixes all the Zenoh key expressions used for routes with the configured `namespace`.
As a consequence, with a bridge configured with `bot1` as namespace:
 - a ROS2 topic `cmd_vel` will be exposed in Zenoh as `bot1/cmd_vel`
 - a remote bridge using the same `bot1` namespace will route the Zenoh key expr `bot1/cmd_vel` as a ROS2 topic `cmd_vel`.
 - a remote bridge using another namespace (or none) will route the Zenoh key expr `bot1/cmd_vel` as a ROS2 topic `bot1/cmd_vel`

In case of multiple robots, this allows to keep the ROS2 nodes running in each robot untouched, without namespace remapping. Then, a control host has the choice:
 - either it controls only 1 robot => run the bridge with the same robot's namespace, and keep the ROS2 control nodes untouched, without namespace remapping
 - either it controls several robots => run the bridge without namespace, and have the ROS2 control node addressing each robot nodes with it's namespace prefix (e.g. `bot1/cmd_vel`)