### PR TITLE
feat: expose stats feature

### DIFF
--- a/zenoh-plugin-ros2dds/Cargo.toml
+++ b/zenoh-plugin-ros2dds/Cargo.toml
@@ -28,6 +28,7 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 default = ["no_mangle"]
+stats = ["zenoh/stats"]
 no_mangle = ["zenoh-plugin-trait/no_mangle"]
 dds_shm = ["cyclors/iceoryx"]
 


### PR DESCRIPTION
Exposing `stats` feature of Zenoh as feature of the plugin.