### PR TITLE
Fix config display in admin space

### DIFF
--- a/zenoh-plugin-ros2dds/src/lib.rs
+++ b/zenoh-plugin-ros2dds/src/lib.rs
@@ -596,8 +596,12 @@ impl<'a> ROS2PluginRuntime<'a> {
     async fn send_admin_reply(&self, query: &Query, key_expr: &keyexpr, admin_ref: &AdminRef) {
         let value: Value = match admin_ref {
             AdminRef::Version => VERSION_JSON_VALUE.clone(),
-            AdminRef::Config => match serde_json::to_value(self) {
-                Ok(v) => v.into(),
+            AdminRef::Config => match serde_json::to_value(&self.config) {
+                Ok(v) => {
+                    println!("SELF: {:?}", self.config);
+                    println!("JSON: {v:?}");
+                    v.into()
+                }
                 Err(e) => {
                     log::error!("INTERNAL ERROR serializing config as JSON: {}", e);
                     return;

--- a/zenoh-plugin-ros2dds/src/lib.rs
+++ b/zenoh-plugin-ros2dds/src/lib.rs
@@ -583,7 +583,7 @@ impl<'a> ROS2PluginRuntime<'a> {
     async fn send_admin_reply(&self, query: &Query, key_expr: &keyexpr, admin_ref: &AdminRef) {
         let value: Value = match admin_ref {
             AdminRef::Version => VERSION_JSON_VALUE.clone(),
-            AdminRef::Config => match serde_json::to_value(&self.config) {
+            AdminRef::Config => match serde_json::to_value(&*self.config) {
                 Ok(v) => v.into(),
                 Err(e) => {
                     log::error!("INTERNAL ERROR serializing config as JSON: {}", e);


### PR DESCRIPTION
Bug:
In admin space for `@ros2/<id>/config` key expr, the value only shows the `domain`.
