### PR TITLE
Improve queries_timeout configuration

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -97,12 +97,24 @@
       // reliable_routes_blocking: true,
 
       ////
-      //// queries_timeout: A duration in seconds (default: 5.0 sec) that will be used as a timeout when the bridge
-      ////                  queries any other remote bridge for discovery information and for historical data for TRANSIENT_LOCAL DDS Readers it serves
-      ////                  (i.e. if the query to the remote bridge exceed the timeout, some historical samples might be not routed to the Readers,
-      ////                  but the route will not be blocked forever).
-      ////
-      // queries_timeout: 5.0,
+      //// queries_timeout: Timeouts configuration for various Zenoh queries.
+      ////                  Each field is optional. If not set, A default value of 5.0 seconds applies.
+      ////                  Each value can be either a float in seconds that will apply as a timeout to all queries,
+      ////                  either a list of strings with format "<regex>=<float>" where:
+      ////                      - "regex" is a regular expression matching an interface name
+      ////                      - "float" is the timeout in seconds
+      // queries_timeout: {
+      //   //// timeouts for TRANSIENT_LOCAL subscriber when querying publishers for historical publications
+      //   transient_local_subscribers: 1.0,
+      //   //// timeouts for Service clients calling a Service server
+      //   services: ["add_two_ints=0.5", ".*=1.0"],
+      //   //// timeouts for Action clients calling an Action server (send_goal, cancel_goal and get_result services)
+      //   actions: {
+      //     send_goal: 1.0,
+      //     cancel_goal: 1.0,
+      //     get_result: [".*long_mission=3600", ".*short_action=10.0"],
+      //   }
+      // }
     },
 
     ////

--- a/zenoh-plugin-ros2dds/src/lib.rs
+++ b/zenoh-plugin-ros2dds/src/lib.rs
@@ -395,8 +395,8 @@ impl<'a> ROS2PluginRuntime<'a> {
                                     // New remote bridge detected
                                     (None, SampleKind::Put) => {
                                         log::info!("New ROS 2 bridge detected: {}", plugin_id);
-                                        // make all routes for a TRANSIENT_LOCAL Subscriber to query historical publications from this new plugin
-                                        routes_mgr.query_historical_all_publications(plugin_id).await;
+                                        // make each routes for a TRANSIENT_LOCAL Subscriber to query historical publications from this new plugin
+                                        routes_mgr.query_all_historical_publications(plugin_id).await;
                                     }
                                     // New remote bridge left
                                     (None, SampleKind::Delete) => log::info!("Remote ROS 2 bridge left: {}", plugin_id),

--- a/zenoh-plugin-ros2dds/src/route_action_cli.rs
+++ b/zenoh-plugin-ros2dds/src/route_action_cli.rs
@@ -75,29 +75,44 @@ impl RouteActionCli<'_> {
         zenoh_key_expr_prefix: OwnedKeyExpr,
         context: Context,
     ) -> Result<RouteActionCli<'a>, String> {
+        // configured queries timeout for calls to send_goal service
+        let send_goal_queries_timeout = context
+            .config
+            .get_queries_timeout_action_send_goal(&ros2_name);
         let route_send_goal = RouteServiceCli::create(
             format!("{ros2_name}/{}", *KE_SUFFIX_ACTION_SEND_GOAL),
             format!("{ros2_type}_SendGoal"),
             &zenoh_key_expr_prefix / *KE_SUFFIX_ACTION_SEND_GOAL,
             &None,
+            send_goal_queries_timeout,
             context.clone(),
         )
         .await?;
 
+        // configured queries timeout for calls to cancel_goal service
+        let cancel_goal_queries_timeout = context
+            .config
+            .get_queries_timeout_action_cancel_goal(&ros2_name);
         let route_cancel_goal = RouteServiceCli::create(
             format!("{ros2_name}/{}", *KE_SUFFIX_ACTION_CANCEL_GOAL),
             ROS2_ACTION_CANCEL_GOAL_SRV_TYPE.to_string(),
             &zenoh_key_expr_prefix / *KE_SUFFIX_ACTION_CANCEL_GOAL,
             &None,
+            cancel_goal_queries_timeout,
             context.clone(),
         )
         .await?;
 
+        // configured queries timeout for calls to get_result service
+        let get_result_queries_timeout = context
+            .config
+            .get_queries_timeout_action_get_result(&ros2_name);
         let route_get_result = RouteServiceCli::create(
             format!("{ros2_name}/{}", *KE_SUFFIX_ACTION_GET_RESULT),
             format!("{ros2_type}_GetResult"),
             &zenoh_key_expr_prefix / *KE_SUFFIX_ACTION_GET_RESULT,
             &None,
+            get_result_queries_timeout,
             context.clone(),
         )
         .await?;

--- a/zenoh-plugin-ros2dds/src/routes_mgr.rs
+++ b/zenoh-plugin-ros2dds/src/routes_mgr.rs
@@ -525,11 +525,9 @@ impl<'a> RoutesMgr<'a> {
         Ok(())
     }
 
-    pub async fn query_historical_all_publications(&mut self, plugin_id: &keyexpr) {
+    pub async fn query_all_historical_publications(&mut self, plugin_id: &keyexpr) {
         for route in self.routes_subscribers.values_mut() {
-            route
-                .query_historical_publications(plugin_id, self.context.config.queries_timeout)
-                .await;
+            route.query_historical_publications(plugin_id).await;
         }
     }
 
@@ -652,12 +650,15 @@ impl<'a> RoutesMgr<'a> {
             Entry::Vacant(entry) => {
                 // ROS2 topic name => Zenoh key expr : strip '/' prefix
                 let zenoh_key_expr = ros2_name_to_key_expr(&ros2_name, &self.context.config);
+                // configured queries timeout for services calls
+                let queries_timeout = self.context.config.get_queries_timeout_service(&ros2_name);
                 // create route
                 let route = RouteServiceCli::create(
                     ros2_name.clone(),
                     ros2_type,
                     zenoh_key_expr.clone(),
                     &None,
+                    queries_timeout,
                     self.context.clone(),
                 )
                 .await?;


### PR DESCRIPTION
Change `queries_timeout` configuration to allow configuration of timeouts for queries per ROS interface.
Different usage of Zenoh queries are involved:
- a route for a TRANSIENT_LOCAL Subscriber querying historical publications from a Publisher served by another bridge
- a route for a Service Client querying a Service Server
- the 3 routes for an Action Client querying `send_goal`, `cancel_goal` and `get_result` from an Action Server

An example of the new configuration:
```json5
      ////
      //// queries_timeout: Timeouts configuration for various Zenoh queries.
      ////                  Each field is optional. If not set, A default value of 5.0 seconds applies.
      ////                  Each value can be either a float in seconds that will apply as a timeout to all queries,
      ////                  either a list of strings with format "<regex>=<float>" where:
      ////                      - "regex" is a regular expression matching an interface name
      ////                      - "float" is the timeout in seconds
      queries_timeout: {
        //// timeouts for TRANSIENT_LOCAL subscriber when querying publishers for historical publications
        transient_local_subscribers: 1.0,
        //// timeouts for Service clients calling a Service server
        services: ["add_two_ints=0.5", ".*=1.0"],
        //// timeouts for Action clients calling an Action server (send_goal, cancel_goal and get_result services)
        actions: {
          send_goal: 1.0,
          cancel_goal: 1.0,
          get_result: [".*long_mission=3600", ".*short_action=10.0"],
        }
      }
```