### PR TITLE
Add --queries-timeout-default option

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -98,12 +98,15 @@
 
       ////
       //// queries_timeout: Timeouts configuration for various Zenoh queries.
-      ////                  Each field is optional. If not set, A default value of 5.0 seconds applies.
+      ////                  Each field is optional. If not set, the 'default' timeout (5.0 seconds by default) applies to all queries.
       ////                  Each value can be either a float in seconds that will apply as a timeout to all queries,
       ////                  either a list of strings with format "<regex>=<float>" where:
       ////                      - "regex" is a regular expression matching an interface name
       ////                      - "float" is the timeout in seconds
       // queries_timeout: {
+      //   //// default timeout that will apply to all query, except the ones specified below
+      //   //// in 'transient_local_subscribers', 'services' and 'actions'
+      //   default: 5.0,
       //   //// timeouts for TRANSIENT_LOCAL subscriber when querying publishers for historical publications
       //   transient_local_subscribers: 1.0,
       //   //// timeouts for Service clients calling a Service server

--- a/zenoh-bridge-ros2dds/src/main.rs
+++ b/zenoh-bridge-ros2dds/src/main.rs
@@ -118,9 +118,10 @@ r#"--pub-max-frequency=[String]...   'Specifies a maximum frequency of publicati
 Repeat this option to configure several topics expressions with a max frequency.'"#
         ))
         .arg(Arg::from_usage(
-r#"--queries-timeout=[float]... 'A float in seconds (default: 5.0 sec) that will be used as a timeout when the bridge
+r#"--queries-timeout-default=[float]... 'A float in seconds (default: 5.0 sec) that will be used as a timeout when the bridge
 queries any other remote bridge for discovery information and for historical data for TRANSIENT_LOCAL DDS Readers it serves
-(i.e. if the query to the remote bridge exceed the timeout, some historical samples might be not routed to the Readers, but the route will not be blocked forever)."#
+(i.e. if the query to the remote bridge exceed the timeout, some historical samples might be not routed to the Readers, but the route will not be blocked forever).
+This value overwrites the value possibly set in configuration file under 'plugins/ros2dds/queries_timeout/default' key."#
         ))
         .arg(Arg::from_usage(
 r#"--watchdog=[PERIOD]   'Experimental!! Run a watchdog thread that monitors the bridge's async executor and reports as error log any stalled status during the specified period (default: 1.0 second)'"#
@@ -180,7 +181,7 @@ r#"--watchdog=[PERIOD]   'Experimental!! Run a watchdog thread that monitors the
         insert_json5!(config, args, "plugins/ros2dds/shm_enabled", if "dds-enable-shm");
     }
     insert_json5!(config, args, "plugins/ros2dds/pub_max_frequencies", for "pub-max-frequency", .collect::<Vec<_>>());
-    insert_json5!(config, args, "plugins/ros2dds/queries_timeout", if "queries-timeout", .parse::<f64>().unwrap());
+    insert_json5!(config, args, "plugins/ros2dds/queries_timeout/default", if "queries-timeout-default", .parse::<f32>().unwrap());
 
     let watchdog_period = if args.is_present("watchdog") {
         args.value_of("watchdog").map(|s| s.parse::<f32>().unwrap())

--- a/zenoh-plugin-ros2dds/src/config.rs
+++ b/zenoh-plugin-ros2dds/src/config.rs
@@ -24,10 +24,7 @@ pub const DEFAULT_DOMAIN: u32 = 0;
 pub const DEFAULT_RELIABLE_ROUTES_BLOCKING: bool = true;
 pub const DEFAULT_TRANSIENT_LOCAL_CACHE_MULTIPLIER: usize = 10;
 pub const DEFAULT_DDS_LOCALHOST_ONLY: bool = false;
-
-lazy_static::lazy_static!(
-    pub static ref DEFAULT_QUERIES_TIMEOUT: Duration = Duration::from_secs_f32(5.0);
-);
+pub const DEFAULT_QUERIES_TIMEOUT: f32 = 5.0;
 
 #[derive(Deserialize, Debug, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -81,8 +78,9 @@ impl Config {
                     return Duration::from_secs_f32(*secs);
                 }
             }
+            return Duration::from_secs_f32(qt.default);
         }
-        *DEFAULT_QUERIES_TIMEOUT
+        Duration::from_secs_f32(DEFAULT_QUERIES_TIMEOUT)
     }
 
     pub fn get_queries_timeout_service(&self, ros2_name: &str) -> Duration {
@@ -92,13 +90,16 @@ impl Config {
                     return Duration::from_secs_f32(*secs);
                 }
             }
+            return Duration::from_secs_f32(qt.default);
         }
-        *DEFAULT_QUERIES_TIMEOUT
+        Duration::from_secs_f32(DEFAULT_QUERIES_TIMEOUT)
     }
 
     pub fn get_queries_timeout_action_send_goal(&self, ros2_name: &str) -> Duration {
         if let Some(QueriesTimeouts {
-            actions: Some(at), ..
+            default,
+            actions: Some(at),
+            ..
         }) = &self.queries_timeout
         {
             for (re, secs) in &at.send_goal {
@@ -106,13 +107,16 @@ impl Config {
                     return Duration::from_secs_f32(*secs);
                 }
             }
+            return Duration::from_secs_f32(*default);
         }
-        *DEFAULT_QUERIES_TIMEOUT
+        Duration::from_secs_f32(DEFAULT_QUERIES_TIMEOUT)
     }
 
     pub fn get_queries_timeout_action_cancel_goal(&self, ros2_name: &str) -> Duration {
         if let Some(QueriesTimeouts {
-            actions: Some(at), ..
+            default,
+            actions: Some(at),
+            ..
         }) = &self.queries_timeout
         {
             for (re, secs) in &at.cancel_goal {
@@ -120,13 +124,16 @@ impl Config {
                     return Duration::from_secs_f32(*secs);
                 }
             }
+            return Duration::from_secs_f32(*default);
         }
-        *DEFAULT_QUERIES_TIMEOUT
+        Duration::from_secs_f32(DEFAULT_QUERIES_TIMEOUT)
     }
 
     pub fn get_queries_timeout_action_get_result(&self, ros2_name: &str) -> Duration {
         if let Some(QueriesTimeouts {
-            actions: Some(at), ..
+            default,
+            actions: Some(at),
+            ..
         }) = &self.queries_timeout
         {
             for (re, secs) in &at.get_result {
@@ -134,14 +141,17 @@ impl Config {
                     return Duration::from_secs_f32(*secs);
                 }
             }
+            return Duration::from_secs_f32(*default);
         }
-        *DEFAULT_QUERIES_TIMEOUT
+        Duration::from_secs_f32(DEFAULT_QUERIES_TIMEOUT)
     }
 }
 
 #[derive(Deserialize, Debug, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct QueriesTimeouts {
+    #[serde(default = "default_queries_timeout")]
+    default: f32,
     #[serde(
         default,
         deserialize_with = "deserialize_vec_regex_f32",
@@ -347,6 +357,10 @@ fn default_domain() -> u32 {
     } else {
         DEFAULT_DOMAIN
     }
+}
+
+fn default_queries_timeout() -> f32 {
+    DEFAULT_QUERIES_TIMEOUT
 }
 
 fn deserialize_path<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>


### PR DESCRIPTION
Fix #28.

- In configuration file, adds a `default` field to the `queries_timeout` as such:
```json5
      //// queries_timeout: Timeouts configuration for various Zenoh queries.
      ////                  Each field is optional, and a default value of 5.0 seconds applies if not set.
      ////                  Each value can be either a timeout (float in seconds) that will apply to all,
      ////                  either a list of strings with format "<regex>=<float>" where:
      ////                      - "regex" is a regular expression matching an interface name
      ////                      - "float" is the timeout in seconds
      queries_timeout: {
        //// default timeout that will apply to all query, except the ones specified below
        //// in 'transient_local_subscribers', 'services' and 'actions'
        default: 7.0,
        //// timeouts for TRANSIENT_LOCAL subscriber when querying publishers for historical publications
        transient_local_subscribers: 8.0,
        //// timeouts for Services clients calling a server
        services: ["add_two_ints=0.1", ".*=1.0"],
        actions: {
          //// timeouts Actions clients calling send_goal
          send_goal: 1.0,
          //// timeouts Actions clients calling cancel_goal
          cancel_goal: 1.0,
          //// timeouts Actions clients calling get_result
          get_result: [".*Mission=3600", ".*Plan=10.0"],
        }
      }
```
- In `zenoh-bridge-dds` command line arguments, replace the `--queries-timeout` option that [was failing](https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/issues/28) with a `--queries-timeout-default` option that set this new `queries_timeout/default` config parameter.