### PR TITLE
Fix routing loop when 2 Subscribers for a same topic exist across 2 bridges

### DIFF
--- a/zenoh-plugin-ros2dds/src/route_publisher.rs
+++ b/zenoh-plugin-ros2dds/src/route_publisher.rs
@@ -418,7 +418,7 @@ fn activate_dds_reader(
             let route_id = route_id.to_string();
             let publisher = publisher.clone();
             move |sample: &DDSRawSample| {
-                do_route_message(sample, &publisher, &route_id);
+                route_dds_message_to_zenoh(sample, &publisher, &route_id);
             }
         },
     )?;
@@ -454,7 +454,7 @@ fn deactivate_dds_reader(
     }
 }
 
-fn do_route_message(sample: &DDSRawSample, publisher: &Arc<Publisher>, route_id: &str) {
+fn route_dds_message_to_zenoh(sample: &DDSRawSample, publisher: &Arc<Publisher>, route_id: &str) {
     if *LOG_PAYLOAD {
         log::debug!("{route_id}: routing message - payload: {:02x?}", sample);
     } else {

--- a/zenoh-plugin-ros2dds/src/route_publisher.rs
+++ b/zenoh-plugin-ros2dds/src/route_publisher.rs
@@ -67,14 +67,14 @@ pub struct RoutePublisher<'a> {
     // the context
     #[serde(skip)]
     context: Context,
-    // the zenoh publisher used to re-publish to zenoh the data received by the DDS Reader
+    // the zenoh publisher used to re-publish to zenoh the message received by the DDS Reader
     // `None` when route is created on a remote announcement and no local ROS2 Subscriber discovered yet
     #[serde(
         rename = "publication_cache_size",
         serialize_with = "serialize_pub_cache"
     )]
     zenoh_publisher: ZPublisher,
-    // the local DDS Reader created to serve the route (i.e. re-publish to zenoh data coming from DDS)
+    // the local DDS Reader created to serve the route (i.e. re-publish to zenoh message coming from DDS)
     #[serde(serialize_with = "serialize_atomic_entity_guid")]
     dds_reader: Arc<AtomicDDSEntity>,
     // TypeInfo for Reader creation (if available)
@@ -129,7 +129,7 @@ impl RoutePublisher<'_> {
         );
 
         // create the zenoh Publisher
-        // if Reader shall be TRANSIENT_LOCAL, use a PublicationCache to store historical data
+        // if Reader shall be TRANSIENT_LOCAL, use a PublicationCache to store historical messages
         let transient_local = is_transient_local(&reader_qos);
         let (cache, cache_size): (Option<PublicationCache>, usize) = if transient_local {
             #[allow(non_upper_case_globals)]
@@ -405,7 +405,7 @@ fn activate_dds_reader(
     let type_name = ros2_message_type_to_dds_type(ros2_type);
     let read_period = get_read_period(&context.config, ros2_name);
 
-    // create matching DDS Reader that forwards data coming from DDS to Zenoh
+    // create matching DDS Reader that forwards message coming from DDS to Zenoh
     let reader = create_dds_reader(
         context.participant,
         topic_name.clone(),

--- a/zenoh-plugin-ros2dds/src/route_subscriber.rs
+++ b/zenoh-plugin-ros2dds/src/route_subscriber.rs
@@ -166,7 +166,7 @@ impl RouteSubscriber<'_> {
         let ros2_name = self.ros2_name.clone();
         let dds_writer = self.dds_writer;
         let subscriber_callback = move |s: Sample| {
-            do_route_message(s, &ros2_name, dds_writer);
+            route_zenoh_message_to_dds(s, &ros2_name, dds_writer);
         };
 
         // create zenoh subscriber
@@ -333,7 +333,7 @@ impl RouteSubscriber<'_> {
     }
 }
 
-fn do_route_message(s: Sample, ros2_name: &str, data_writer: dds_entity_t) {
+fn route_zenoh_message_to_dds(s: Sample, ros2_name: &str, data_writer: dds_entity_t) {
     if *LOG_PAYLOAD {
         log::debug!(
             "Route Subscriber (Zenoh:{} -> ROS:{}): routing message - payload: {:02x?}",

--- a/zenoh-plugin-ros2dds/src/routes_mgr.rs
+++ b/zenoh-plugin-ros2dds/src/routes_mgr.rs
@@ -27,6 +27,7 @@ use crate::route_service_cli::RouteServiceCli;
 use crate::route_service_srv::RouteServiceSrv;
 use crate::route_subscriber::RouteSubscriber;
 use cyclors::dds_entity_t;
+use cyclors::qos::IgnoreLocal;
 use cyclors::qos::Qos;
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::Entry;
@@ -329,6 +330,10 @@ impl<'a> RoutesMgr<'a> {
                 keyless,
                 writer_qos,
             } => {
+                let mut qos = writer_qos.clone();
+                qos.ignore_local = Some(IgnoreLocal {
+                    kind: cyclors::qos::IgnoreLocalKind::PARTICIPANT,
+                });
                 // On remote Publisher route announcement, prepare a Subscriber route
                 // with an associated DDS Writer allowing local ROS2 Nodes to discover it
                 let route = self
@@ -336,7 +341,7 @@ impl<'a> RoutesMgr<'a> {
                         key_expr_to_ros2_name(&zenoh_key_expr, &self.context.config),
                         ros2_type,
                         keyless,
-                        writer_qos,
+                        qos,
                         true,
                     )
                     .await?;
@@ -368,6 +373,10 @@ impl<'a> RoutesMgr<'a> {
                 keyless,
                 reader_qos,
             } => {
+                let mut qos = reader_qos.clone();
+                qos.ignore_local = Some(IgnoreLocal {
+                    kind: cyclors::qos::IgnoreLocalKind::PARTICIPANT,
+                });
                 // On remote Subscriber route announcement, prepare a Publisher route
                 // with an associated DDS Reader allowing local ROS2 Nodes to discover it
                 let route = self
@@ -375,7 +384,7 @@ impl<'a> RoutesMgr<'a> {
                         key_expr_to_ros2_name(&zenoh_key_expr, &self.context.config),
                         ros2_type,
                         keyless,
-                        reader_qos,
+                        qos,
                         true,
                     )
                     .await?;


### PR DESCRIPTION
In a setup with 2 interconnected bridges, with for instance one on domain 0 and the other one on domain 1:
if in domain 0 there are a Publisher and a Subscriber on a same topic `T` and in domain 1 a Subscriber on topic `T`, then the Subscriber in domain 1 receives twice each publication.

E.g. to reproduce on a single host:
 - `ROS_DOMAIN_ID=0 ros2 run demo_nodes_cpp talker`
 - `ROS_DOMAIN_ID=0 ros2 run demo_nodes_cpp listener`
 - `ROS_DOMAIN_ID=0 zenoh-bridge-ros2dds`
 - `ROS_DOMAIN_ID=1 zenoh-bridge-ros2dds`
 - `ROS_DOMAIN_ID=1 ros2 run demo_nodes_cpp listener`

The problem comes from bridge on domain 1 that re-publishes to DDS the data coming from bridge on domain 0, but also receives back this publication and route it back to the bridge on domain 0.
The cause is the DDS Writers (and DDS Readers) created by the bridge on a remote announcement of route copy the same declared QoS without adding the `ignore_local(Participant)` QoS. Adding this QoS will make the bridge to ignore its own publications over DDS, avoiding to route them back.

This PR fixes that.