### PR TITLE
Support '--ros-args -r' for __node and __ns

### DIFF
--- a/zenoh-bridge-ros2dds/src/bridge_args.rs
+++ b/zenoh-bridge-ros2dds/src/bridge_args.rs
@@ -74,6 +74,16 @@ pub struct BridgeArgs {
     /// reports as error log any stalled status during the specified period [default: 1.0 second]
     #[arg(short, long, value_name = "FLOAT", default_missing_value = "1.0")]
     pub watchdog: Option<Option<f32>>,
+
+    /// ROS command line arguments as specified in https://design.ros2.org/articles/ros_command_line_arguments.html
+    /// Supported capabilities:
+    ///   -r, --remap <from:=to> : remapping is supported only for '__ns' and '__node'
+    #[arg(
+        long,
+        value_name = " list of ROS args until '--' ",
+        verbatim_doc_comment
+    )]
+    pub ros_args: (),
 }
 
 impl From<BridgeArgs> for Config {
@@ -119,7 +129,7 @@ impl From<&BridgeArgs> for Config {
     }
 }
 
-fn insert_json5<T>(config: &mut Config, key: &str, value: &T)
+pub(crate) fn insert_json5<T>(config: &mut Config, key: &str, value: &T)
 where
     T: Sized + serde::Serialize,
 {
@@ -128,7 +138,7 @@ where
         .unwrap();
 }
 
-fn insert_json5_option<T>(config: &mut Config, key: &str, value: &Option<T>)
+pub(crate) fn insert_json5_option<T>(config: &mut Config, key: &str, value: &Option<T>)
 where
     T: Sized + serde::Serialize,
 {
@@ -139,7 +149,7 @@ where
     }
 }
 
-fn insert_json5_list<T>(config: &mut Config, key: &str, values: &Vec<T>)
+pub(crate) fn insert_json5_list<T>(config: &mut Config, key: &str, values: &Vec<T>)
 where
     T: Sized + serde::Serialize,
 {

--- a/zenoh-bridge-ros2dds/src/ros_args.rs
+++ b/zenoh-bridge-ros2dds/src/ros_args.rs
@@ -1,0 +1,80 @@
+//
+// Copyright (c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use zenoh::config::Config;
+
+use crate::bridge_args::insert_json5;
+
+#[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]
+pub struct RosArgs {
+    /// Name remapping
+    #[arg(short, long, value_name = "FROM:=TO", value_parser = parse_remap)]
+    pub remap: Vec<Remap>,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+enum RemapFrom {
+    Namespace,
+    Node,
+    _Name(String),
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct Remap {
+    from: RemapFrom,
+    to: String,
+}
+
+fn parse_remap(s: &str) -> Result<Remap, String> {
+    match s.split_once(":=") {
+        Some(("__ns", to)) if !to.is_empty() => Ok(Remap {
+            from: RemapFrom::Namespace,
+            to: to.into(),
+        }),
+        Some(("__node", to)) if !to.is_empty() => Ok(Remap {
+            from: RemapFrom::Node,
+            to: to.into(),
+        }),
+        Some((from, to)) if !from.is_empty() && !to.is_empty() => {
+            Err("only remapping for '__ns' and '__node' are currently supported".into())
+        }
+        _ => Err("valid value must have format 'fromp:=to'".into()),
+    }
+}
+
+impl RosArgs {
+    pub fn update_config(&self, config: &mut Config) {
+        for r in &self.remap {
+            match r.from {
+                RemapFrom::Namespace => {
+                    log::info!(
+                        "Remapping namespace to '{}' as per ROS command line argument",
+                        r.to
+                    );
+                    insert_json5(config, "plugins/ros2dds/namespace", &r.to);
+                }
+                RemapFrom::Node => {
+                    log::info!(
+                        "Remapping node name to '{}' as per ROS command line argument",
+                        r.to
+                    );
+                    insert_json5(config, "plugins/ros2dds/nodename", &r.to);
+                }
+                RemapFrom::_Name(_) => {
+                    panic!("Unsupported remapping... only '__node' and '__ns' are supported")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add the parsing of `--ros-args` command line arguments as per specification from https://design.ros2.org/articles/ros_command_line_arguments.html.
And manage the `-r`,`--remap <from:=to>` arguments only for namespace (from == '__ns') and node name (from == `__node`).

Closes #48 
