### PR TITLE
fix: Set `publish = false` for zenoh-bridge-ros2dds

### DIFF
--- a/zenoh-bridge-ros2dds/Cargo.toml
+++ b/zenoh-bridge-ros2dds/Cargo.toml
@@ -21,6 +21,7 @@ homepage = { workspace = true }
 license = { workspace = true }
 categories = ["network-programming"]
 description = "Zenoh bridge for ROS 2 and DDS in general"
+publish = false
 
 [features]
 dds_shm = ["zenoh-plugin-ros2dds/dds_shm"]


### PR DESCRIPTION
Resolves https://github.com/eclipse-zenoh/ci/issues/9.