### PR TITLE
Change zenoh-bridge-ros2dds to router mode by default

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -143,17 +143,19 @@
   },
 
   ////
-  //// zenoh related configuration (see zenoh documentation for more details)
+  //// Zenoh related configuration.
+  //// Only the most relevant sections are displayed here.
+  //// For a complete view of configuration possibilities, see https://github.com/eclipse-zenoh/zenoh/blob/main/DEFAULT_CONFIG.json5
   ////
 
   ////
-  //// mode: The bridge's mode (peer or client)
+  //// mode: The bridge's mode (router, peer or client)
   ////
-  //mode: "client",
+  //mode: "router",
 
   ////
   //// Which endpoints to connect to. E.g. tcp/localhost:7447.
-  //// By configuring the endpoints, it is possible to tell zenoh which router/peer to connect to at startup.
+  //// By configuring the endpoints, it is possible to tell zenoh which remote router or other zenoh-bridge-ros2dds to connect to at startup.
   ////
   connect: {
     endpoints: [
@@ -162,13 +164,51 @@
   },
 
   ////
-  //// Which endpoints to listen on. E.g. tcp/localhost:7447.
+  //// Which endpoints to listen on.
   //// By configuring the endpoints, it is possible to tell zenoh which are the endpoints that other routers,
   //// peers, or client can use to establish a zenoh session.
+  //// In 'router' mode (default) the zenoh-bridge-ros2dds is listening by default on `tcp/0.0.0.0:7447` (`0.0.0.0` meaning all the available network interfaces)
   ////
   listen: {
     endpoints: [
       // "<proto>/<ip>:<port>"
     ]
   },
+
+  ////
+  //// Configure the scouting mechanisms and their behaviours
+  ////
+  //scouting: {
+  //  /// The UDP multicast scouting configuration.
+  //  multicast: {
+  //    /// Whether multicast scouting is enabled or not
+  //    enabled: true,
+  //    /// The socket which should be used for multicast scouting
+  //    address: "224.0.0.224:7446",
+  //    /// The network interface which should be used for multicast scouting
+  //    interface: "auto", // If not set or set to "auto" the interface if picked automatically
+  //    /// Which type of Zenoh instances to automatically establish sessions with upon discovery on UDP multicast.
+  //    /// Accepts a single value or different values for router, peer and client.
+  //    /// Each value is bit-or-like combinations of "peer", "router" and "client".
+  //    autoconnect: { router: "", peer: "router|peer" },
+  //    /// Whether or not to listen for scout messages on UDP multicast and reply to them.
+  //    listen: true,
+  //  },
+  //  /// The gossip scouting configuration.
+  //  gossip: {
+  //    /// Whether gossip scouting is enabled or not
+  //    enabled: true,
+  //    /// When true, gossip scouting informations are propagated multiple hops to all nodes in the local network.
+  //    /// When false, gossip scouting informations are only propagated to the next hop.
+  //    /// Activating multihop gossip implies more scouting traffic and a lower scalability.
+  //    /// It mostly makes sense when using "linkstate" routing mode where all nodes in the subsystem don't have
+  //    /// direct connectivity with each other.
+  //    multihop: false,
+  //    /// Which type of Zenoh instances to automatically establish sessions with upon discovery on gossip.
+  //    /// Accepts a single value or different values for router, peer and client.
+  //    /// Each value is bit-or-like combinations of "peer", "router" and "client".
+  //    autoconnect: { router: "", peer: "router|peer" },
+  //  },
+  //},
+
 }

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ To make sure of this, you can either:
   ```
 
 On the robot, run:
-  - `zenoh-bridge-ros2dds -l tcp/0.0.0.0:7447`
+  - `zenoh-bridge-ros2dds`
 
 On the operating host run:
   - `zenoh-bridge-ros2dds -e tcp/<robot-ip>:7447`
@@ -184,6 +184,33 @@ The `"ros2dds"` part of this same configuration file can also be used in the con
 - `zenoh-bridge-ros2dds -h`
 
 The command line arguments overwrite the equivalent keys configured in a configuration file.
+
+## Connectivity configurations
+
+### DDS communications
+The bridge discovers all ROS 2 Nodes and their topics/services/actions running on the same Domain ID (set via `ROS_DOMAIN_ID` or `0` by default) via UDP multicast, as per DDS specification.
+
+As the bridge relies on [CycloneDDS](https://github.com/eclipse-cyclonedds/cyclonedds), it's DDS communications can be configured via a CycloneDDS XML configuration file as explained [here](https://github.com/eclipse-cyclonedds/cyclonedds/tree/8638e1fa1e8ae9f964c91ad4763653702b8f91e0?tab=readme-ov-file#run-time-configuration).
+
+### Zenoh communications
+Starting from **v0.11.0**, the `zenoh-bridge-ros2dds` is by default started in `router` mode (See the difference between modes in Zenoh documentation: https://zenoh.io/docs/getting-started/deployment/).  
+This means it's listening for incoming TCP connections by remote bridges or any Zenoh application on port `7447` via any network interface. It does perform discovery via scouting over UDP multicast or gossip protocol, but doesn't auto-connect to anything.  
+As a consequence the connectivity between bridges has to be statically configured in one bridge connecting to the other (or several other bridges) via the `-e` command line option, or via the `connect` section in [configuration file](DEFAULT_CONFIG.json5).
+
+If required, the automatic connection to other discovered bridges (also running in `router` mode) can be enabled adding such configuration:
+```json5
+  scouting: {
+    multicast: {
+      autoconnect: { router: "router" }
+    },
+    gossip: {
+      autoconnect: { router: "router" }
+    }
+  },
+```
+
+Prior to **v0.11.0**, the `zenoh-bridge-ros2dds` was by default started in `peer` mode.  
+It was listening for incoming TCP connections on a random port (chosen by the OS), and was automatically connecting to any discovered brige, router or peer.
 
 ## Easy multi-robots via Namespace configuration
 

--- a/zenoh-bridge-ros2dds/src/zenoh_args.rs
+++ b/zenoh-bridge-ros2dds/src/zenoh_args.rs
@@ -78,7 +78,9 @@ impl From<&CommonArgs> for Config {
             config.set_mode(value.mode.map(Into::into)).unwrap();
         } else if config.mode().is_none() {
             // no mode set neither via command line, neither in config file - set Router mode by default
-            config.set_mode(Some(zenoh::scouting::WhatAmI::Router)).unwrap();
+            config
+                .set_mode(Some(zenoh::scouting::WhatAmI::Router))
+                .unwrap();
         }
         if !value.connect.is_empty() {
             config.connect.endpoints = value.connect.iter().map(|v| v.parse().unwrap()).collect();


### PR DESCRIPTION
As discussed in #85, the current behaviour of the `zenoh-bridge-ros2dds` is to automatically connect to any other discovered `zenoh-bridge-ros2dds`. This behaviour occurs because the bridge is by default configured as a [Zenoh peer](https://zenoh.io/docs/getting-started/deployment/).
This is not a desirable behaviour for robotic since it leads all robots in a LAN to automatically interconnect with each other.

Most of the time, users would like to control the connectivity between bridges, establishing connections only between a control host and each robot.

This PR changes the default mode of the bridge to `router`, thus by default:
- it listens on `tcp/0.0.0.0:7447``
- it doesn't automatically connect to anything

Closes #85