### PR TITLE
Debian pkg: add a conffiles to avoid overrwriting a modified conf.json5

### DIFF
--- a/zenoh-bridge-ros2dds/Cargo.toml
+++ b/zenoh-bridge-ros2dds/Cargo.toml
@@ -72,3 +72,4 @@ assets = [
         "644",
     ],
 ]
+conf-files = ["/etc/zenoh-bridge-ros2dds/conf.json5"]


### PR DESCRIPTION
Fix #78 

This PR adds a [`conffiles`](https://www.debian.org/doc/manuals/maint-guide/dother.en.html#conffiles) file in the Debian package for `zenoh-bridge-ros2dds` that references the `/etc/zenoh-bridge-ros2dds/conf.json5` configuration file.
Thus, if modified, it will not been overwritten when upgrading the package.