### PR TITLE
zenoh-bridge-ros2dds: fix static loading of plugin

### DIFF
--- a/zenoh-bridge-ros2dds/src/zenoh_args.rs
+++ b/zenoh-bridge-ros2dds/src/zenoh_args.rs
@@ -30,12 +30,12 @@ impl core::fmt::Display for Wai {
     }
 }
 
-impl Into<zenoh::scouting::WhatAmI> for Wai {
-    fn into(self) -> zenoh::scouting::WhatAmI {
-        match self {
-            Self::Peer => zenoh::scouting::WhatAmI::Peer,
-            Self::Client => zenoh::scouting::WhatAmI::Client,
-            Self::Router => zenoh::scouting::WhatAmI::Router,
+impl From<Wai> for zenoh::scouting::WhatAmI {
+    fn from(val: Wai) -> Self {
+        match val {
+            Wai::Peer => zenoh::scouting::WhatAmI::Peer,
+            Wai::Client => zenoh::scouting::WhatAmI::Client,
+            Wai::Router => zenoh::scouting::WhatAmI::Router,
         }
     }
 }

--- a/zenoh-plugin-ros2dds/src/lib.rs
+++ b/zenoh-plugin-ros2dds/src/lib.rs
@@ -116,7 +116,7 @@ impl Plugin for ROS2Plugin {
 
     const PLUGIN_VERSION: &'static str = plugin_version!();
     const PLUGIN_LONG_VERSION: &'static str = plugin_long_version!();
-    const DEFAULT_NAME: &'static str = "zenoh-plugin-ros2dds";
+    const DEFAULT_NAME: &'static str = "ros2dds";
 
     fn start(name: &str, runtime: &Self::StartArgs) -> ZResult<zenoh::plugins::RunningPlugin> {
         // Try to initiate login.
@@ -143,7 +143,7 @@ pub async fn run(runtime: Runtime, config: Config) {
     // But cannot be done twice in case of static link.
     zenoh_util::try_init_log_from_env();
     tracing::debug!("ROS2 plugin {}", ROS2Plugin::PLUGIN_VERSION);
-    tracing::info!("ROS2 plugin {:?}", config);
+    tracing::info!("ROS2 plugin {config:?}");
 
     // Check config validity
     if !regex::Regex::new("/[A-Za-z0-9_/]*")


### PR DESCRIPTION
Make the `zenoh-bridge-ros2dds` to use the PluginManager to declare the static plugins, rather than relying on the `zenoh::open()` that would try to load the plugins as dynamic lib.

Fix #123 