### PR TITLE
chore: renamed no_mangle feature to dynamic_plugin

### DIFF
--- a/zenoh-plugin-ros2dds/Cargo.toml
+++ b/zenoh-plugin-ros2dds/Cargo.toml
@@ -27,9 +27,9 @@ name = "zenoh_plugin_ros2dds"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["no_mangle"]
+default = ["dynamic_plugin"]
 stats = ["zenoh/stats"]
-no_mangle = []
+dynamic_plugin = []
 dds_shm = ["cyclors/iceoryx"]
 
 [dependencies]

--- a/zenoh-plugin-ros2dds/src/lib.rs
+++ b/zenoh-plugin-ros2dds/src/lib.rs
@@ -103,7 +103,7 @@ const CYCLONEDDS_CONFIG_ENABLE_SHM: &str = r#"<CycloneDDS><Domain><SharedMemory>
 const ROS_DISCOVERY_INFO_POLL_INTERVAL_MS: u64 = 100;
 const ROS_DISCOVERY_INFO_PUSH_INTERVAL_MS: u64 = 100;
 
-#[cfg(feature = "no_mangle")]
+#[cfg(feature = "dynamic_plugin")]
 zenoh_plugin_trait::declare_plugin!(ROS2Plugin);
 
 #[allow(clippy::upper_case_acronyms)]


### PR DESCRIPTION
As suggested by @milyin this PR renames the `no_mangle` feature to `dynamic_plugin` which is easier to understand.
- Sister of: https://github.com/eclipse-zenoh/zenoh/pull/1010