### PR TITLE
Add an optional ":express" flag to "pub_priorities" configuration

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -81,15 +81,15 @@
       //// pub_priorities: Specify a list of priorities of publications routing over zenoh for a set of Publishers.
       ////                 In case of high traffic, the publications with higher priorities will overtake
       ////                 the publications with lower priorities in Zenoh publication queues.
-      ////                 The strings must have the format "<regex>=<integer>":
+      ////                 The strings must have the format "<regex>=<integer>[:express]":
       ////                 - "regex" is a regular expression matching a Publisher topic name
       ////                 - "integer" is a priority value in the range [1-7]. Highest priority is 1, lowest is 7 and default is 5.
       ////                   (see Zenoh Priority definition here: https://docs.rs/zenoh/latest/zenoh/publication/enum.Priority.html)
-      ////                For topics configured with 1 as priority, the Zenoh "express" option is also used for publications, meaning
-      ////                the messages will not be batched with other messages. Bypassing batching queues brings lower latency.
-      ////                But the tradeoff is more overhead per-message and thus higher bandwidth consumption.
-      ////
-      // pub_priorities: ["/pose=2", "/rosout=7"],
+      ////                - ":express" is an option to indicate that the Zenoh express policy must be used for those publications.
+      ////                   The express policy makes Zenoh to to send the message immediatly, not waiting for possible further messages
+      ////                   to create a bigger batch of messages. This usually has a positive impact on latency for the topic
+      ////                   but a negative impact on the general throughput, as more overhead is used for those topics.
+      // pub_priorities: ["/scan=1:express", "/pose=2", "/rosout=7"],
 
       ////
       //// reliable_routes_blocking: When true, the publications from a RELIABLE DDS Writer will be

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -82,9 +82,12 @@
       ////                 In case of high traffic, the publications with higher priorities will overtake
       ////                 the publications with lower priorities in Zenoh publication queues.
       ////                 The strings must have the format "<regex>=<integer>":
-      ////                 - "regex" is a regular expression matching a Publisher interface name
+      ////                 - "regex" is a regular expression matching a Publisher topic name
       ////                 - "integer" is a priority value in the range [1-7]. Highest priority is 1, lowest is 7 and default is 5.
       ////                   (see Zenoh Priority definition here: https://docs.rs/zenoh/latest/zenoh/publication/enum.Priority.html)
+      ////                For topics configured with 1 as priority, the Zenoh "express" option is also used for publications, meaning
+      ////                the messages will not be batched with other messages. Bypassing batching queues brings lower latency.
+      ////                But the tradeoff is more overhead per-message and thus higher bandwidth consumption.
       ////
       // pub_priorities: ["/pose=2", "/rosout=7"],
 

--- a/zenoh-plugin-ros2dds/src/route_publisher.rs
+++ b/zenoh-plugin-ros2dds/src/route_publisher.rs
@@ -206,17 +206,21 @@ impl RoutePublisher<'_> {
         };
 
         // Priority if configured for this topic
-        let priority = context
+        let (priority, is_express) = context
             .config
-            .get_pub_priorities(&ros2_name)
+            .get_pub_priority_and_express(&ros2_name)
             .unwrap_or_default();
+        println!(
+            "!!!!! {} => {:?} + express:{}",
+            ros2_name, priority, is_express
+        );
 
         let publisher: Arc<Publisher<'static>> = context
             .zsession
             .declare_publisher(zenoh_key_expr.clone())
             .allowed_destination(Locality::Remote)
             .congestion_control(congestion_ctrl)
-            .express(priority == Priority::RealTime)
+            .express(is_express)
             .priority(priority)
             .await
             .map_err(|e| format!("Failed create Publisher for key {zenoh_key_expr}: {e}",))?

--- a/zenoh-plugin-ros2dds/src/route_publisher.rs
+++ b/zenoh-plugin-ros2dds/src/route_publisher.rs
@@ -216,6 +216,7 @@ impl RoutePublisher<'_> {
             .declare_publisher(zenoh_key_expr.clone())
             .allowed_destination(Locality::Remote)
             .congestion_control(congestion_ctrl)
+            .express(priority == Priority::RealTime)
             .priority(priority)
             .await
             .map_err(|e| format!("Failed create Publisher for key {zenoh_key_expr}: {e}",))?


### PR DESCRIPTION
The plugin/bridge can already be configured with different priorities per routed publications via the `"pub_priorities"` setting.

This PR allows for this setting an optional `":express"` flag to be added as a suffix after each priority.
e.g.: `pub_priorities: ["/scan=1:express", "/pose=2", "/rosout=7"],`

When set this flag makes the plugin to use  Zenoh's [`express()`](https://docs.rs/zenoh/1.0.0-alpha.6/zenoh/pubsub/struct.PublisherBuilder.html#method.express) policy when routing the publications.
This usually has a positive impact on latency for the topic but a negative impact on the general throughput, as more overhead is used for those topics.