### PR TITLE
Fix -i / --id option: remap it to the ZenohID

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -161,6 +161,12 @@
   //// For a complete view of configuration possibilities, see https://github.com/eclipse-zenoh/zenoh/blob/main/DEFAULT_CONFIG.json5
   ////
 
+  /// The identifier (as unsigned 128bit integer in hexadecimal lowercase - leading zeros are not accepted)
+  /// that zenoh runtime will use.
+  /// If not set, a random unsigned 128bit integer will be used.
+  /// WARNING: this id must be unique in your zenoh network.
+  // id: "1234567890abcdef",
+
   ////
   //// mode: The bridge's mode (router, peer or client)
   ////

--- a/README.md
+++ b/README.md
@@ -228,8 +228,10 @@ NOTE: the bridge prefixes ALL topics/services/actions names with the configured 
 
 ## Admin space
 
-The bridge exposes some internal states via a Zenoh admin space under `@/<id>/ros2/**`, where `<id>` is the unique id of the bridge (configurable).  
-This admin space can be queried via Zenoh `get()` operation. If the REST plugin is configured for the bridge for instance via `--rest-http-port 8000` argument, those URLs can be queried:
-- [http://\<bridge-IP\>:8000/@/\<id\>/ros2/dds/**]() : to get all the DDS Readers/Writers discovered by the bridge
-- [http://\<bridge-IP\>:8000/@/\<id\>/ros2/node/**]() : to get all ROS nodes with their interfaces discovered by the bridge
-- [http://\<bridge-IP\>:8000/@/\<id\>/ros2/route/**]() : to get all routes between ROS interfaces and Zenoh established by the bridge
+The bridge exposes some internal states via a Zenoh admin space under `@/<id>/ros2/**`, where `<id>` is the unique Zenoh ID of the bridge (configurable).  
+This admin space can be queried via Zenoh `get()` operation. If the REST plugin is configured for the bridge for instance via `--rest-http-port 8000` argument, such URLs can be queried:
+- [http://\<bridge-IP\>:8000/@/local/ros2/node/**]() : to get all ROS nodes with their interfaces discovered by the bridge
+- [http://\<bridge-IP\>:8000/@/local/ros2/dds/**]() : to get all the DDS Readers/Writers discovered by the bridge
+- [http://\<bridge-IP\>:8000/@/local/ros2/route/**]() : to get all routes between ROS interfaces and Zenoh established by the bridge
+- [http://\<bridge-IP\>:8000/@/*/ros2/node/**]() : to get all ROS nodes discovered by all bridges
+- [http://\<bridge-IP\>:8000/@/*/ros2/route/**/cmd_vel]() : to get all routes between established by all bridges on `cmd_vel` topic

--- a/zenoh-bridge-ros2dds/src/bridge_args.rs
+++ b/zenoh-bridge-ros2dds/src/bridge_args.rs
@@ -28,11 +28,6 @@ use crate::zenoh_args::CommonArgs;
 pub struct BridgeArgs {
     #[command(flatten)]
     pub session_args: CommonArgs,
-    /// The identifier (as an hexadecimal string, with odd number of chars - e.g.: 0A0B23...) that zenohd must use.
-    /// WARNING: this identifier must be unique in the system and must be 16 bytes maximum (32 chars)!
-    /// If not set, a random UUIDv4 will be used.
-    #[arg(short, long, verbatim_doc_comment)]
-    pub id: Option<String>,
     /// A ROS 2 namespace to be used by the "zenoh_bridge_dds" node'
     #[arg(short, long)]
     pub namespace: Option<String>,
@@ -97,7 +92,6 @@ impl From<&BridgeArgs> for Config {
     fn from(args: &BridgeArgs) -> Self {
         let mut config = (&args.session_args).into();
 
-        insert_json5_option(&mut config, "plugins/ros2dds/id", &args.id);
         insert_json5_option(&mut config, "plugins/ros2dds/namespace", &args.namespace);
         if let Some(domain) = args.domain {
             insert_json5(&mut config, "plugins/ros2dds/domain", &domain);

--- a/zenoh-bridge-ros2dds/src/zenoh_args.rs
+++ b/zenoh-bridge-ros2dds/src/zenoh_args.rs
@@ -46,6 +46,10 @@ pub struct CommonArgs {
     /// A configuration file.
     pub config: Option<String>,
     #[arg(short, long)]
+    /// The Zenoh identifier (as an hexadecimal string, in lowercase - e.g.: a0b23...) that this bridge must use. If not set, a random unsigned 128bit integer will be used.
+    /// WARNING: this id must be unique in the system and must be 32 chars maximum (128 bits)!
+    #[arg(short, long)]
+    id: Option<String>,
     /// The Zenoh session mode [default: router].
     pub mode: Option<Wai>,
     #[arg(short = 'e', long)]
@@ -73,9 +77,17 @@ impl From<&CommonArgs> for Config {
             Some(path) => Config::from_file(path).unwrap(),
             None => Config::default(),
         };
+        if let Some(id) = &value.id {
+            let _ = config.set_id(
+                id.parse()
+                    .expect("Error with option --id (expecting a hexadecimal ZenohId)"),
+            );
+        }
         if value.mode.is_some() {
             // apply mode set via command line, overwritting mode set in config file
-            config.set_mode(value.mode.map(Into::into)).unwrap();
+            config
+                .set_mode(value.mode.map(Into::into))
+                .expect("Error with option --mode");
         } else if config.mode().is_none() {
             // no mode set neither via command line, neither in config file - set Router mode by default
             config

--- a/zenoh-bridge-ros2dds/src/zenoh_args.rs
+++ b/zenoh-bridge-ros2dds/src/zenoh_args.rs
@@ -46,7 +46,7 @@ pub struct CommonArgs {
     /// A configuration file.
     pub config: Option<String>,
     #[arg(short, long)]
-    /// The Zenoh identifier (as an hexadecimal string, in lowercase - e.g.: a0b23...) that this bridge must use. If not set, a random unsigned 128bit integer will be used.
+    /// The Zenoh identifier (as an hexadecimal string, in lowercase - e.g.: a0b23...) that this bridge must use. If not set, a random unsigned 128bit integer will be used. Leading zeros are not accepted.
     /// WARNING: this id must be unique in the system and must be 32 chars maximum (128 bits)!
     #[arg(short, long)]
     id: Option<String>,


### PR DESCRIPTION
Following https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/pull/179 the `id` configuration have been removed from the plugin configuration. Then the `-i`/`--id` option was returning an error.

This PR re-map the `-i`/`--id` option of the bridge to the Zenoh ID configuration for its Session.
As a consequence the id can no longer be a free string, but must be a lowercase hexadecimal string with 32 characters maximum (128 bits maximum for a Zenoh ID). It must be unique in the system (i.e. not the same id for 2 bridges).