### PR TITLE
make upgrade command known to postrm

### DIFF
--- a/zenoh-bridge-ros2dds/.deb/postrm
+++ b/zenoh-bridge-ros2dds/.deb/postrm
@@ -23,7 +23,8 @@ case "$1" in
     userdel zenoh-bridge-ros2dds > /dev/null 2>&1 || true
     rm -rf /etc/zenoh-bridge-ros2dds
     ;;
-
+    upgrade)
+    ;;
     *)
         echo "postrm called with unknown argument \`$1'" >&2
         exit 1


### PR DESCRIPTION
While running apt upgrade, the postrm would return with an error due to unknown argument upgrade (see third line): 
```
Preparing to unpack .../zenoh-bridge-ros2dds_1.0.0~beta.2-1_amd64.deb ...
Unpacking zenoh-bridge-ros2dds (1.0.0~beta.2-1) over (1.0.0~beta.1-1) ...
postrm called with unknown argument `upgrade'
dpkg: warning: old zenoh-bridge-ros2dds package post-removal script subprocess returned error exit status 1
dpkg: trying script from the new package instead ...
postrm called with unknown argument `failed-upgrade'
dpkg: error processing archive /var/cache/apt/archives/zenoh-bridge-ros2dds_1.0.0~beta.2-1_amd64.deb (--unpack):
 new zenoh-bridge-ros2dds package post-removal script subprocess returned error exit status 1
postrm called with unknown argument `abort-upgrade'
dpkg: error while cleaning up:
 new zenoh-bridge-ros2dds package post-removal script subprocess returned error exit status 1
Errors were encountered while processing:
 /var/cache/apt/archives/zenoh-bridge-ros2dds_1.0.0~beta.2-1_amd64.deb
needrestart is being skipped since dpkg has failed
```

I am deliberately not handling the failed-upgrade and abort-upgrade as I think they should return an error message.