### PR TITLE
Align Rust with Reliability exported in zenoh::qos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4382,7 +4382,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4451,7 +4451,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "zenoh-collections",
 ]
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "tracing",
  "uhlc",
@@ -4470,12 +4470,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 
 [[package]]
 name = "zenoh-config"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "json5",
  "num_cpus",
@@ -4496,7 +4496,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -4507,7 +4507,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "aes 0.8.4",
  "hmac 0.12.1",
@@ -4520,7 +4520,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "bincode",
  "flume",
@@ -4536,7 +4536,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "hashbrown",
  "keyed-set",
@@ -4550,7 +4550,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -4567,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "flume",
@@ -4590,7 +4590,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4615,7 +4615,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "socket2 0.5.7",
@@ -4632,7 +4632,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4659,7 +4659,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "socket2 0.5.7",
@@ -4678,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "nix",
@@ -4696,7 +4696,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4716,7 +4716,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4727,7 +4727,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-rest"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4776,7 +4776,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "git-version",
  "libloading",
@@ -4792,7 +4792,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "const_format",
  "rand 0.8.5",
@@ -4806,7 +4806,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "anyhow",
 ]
@@ -4814,7 +4814,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "lazy_static",
  "ron",
@@ -4827,7 +4827,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "event-listener 5.3.1",
  "futures",
@@ -4840,7 +4840,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "futures",
  "tokio",
@@ -4853,7 +4853,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -4886,7 +4886,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "const_format",

--- a/zenoh-plugin-ros2dds/src/route_publisher.rs
+++ b/zenoh-plugin-ros2dds/src/route_publisher.rs
@@ -28,8 +28,8 @@ use serde::{Serialize, Serializer};
 use zenoh::{
     key_expr::{keyexpr, OwnedKeyExpr},
     liveliness::LivelinessToken,
-    pubsub::{Publisher, Reliability},
-    qos::{CongestionControl, Priority},
+    pubsub::Publisher,
+    qos::{CongestionControl, Priority, Reliability},
     sample::Locality,
     Wait,
 };


### PR DESCRIPTION
Move zenoh::pubsub::Reliability to zenoh::qos::Reliability. To be merged after https://github.com/eclipse-zenoh/zenoh/pull/1457.