### PR TITLE
Use new Serialization and zenoh-ext API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4383,7 +4383,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4451,7 +4451,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "zenoh-collections",
 ]
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "tracing",
  "uhlc",
@@ -4470,12 +4470,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 
 [[package]]
 name = "zenoh-config"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "json5",
  "num_cpus",
@@ -4496,7 +4496,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -4507,7 +4507,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "aes 0.8.4",
  "hmac 0.12.1",
@@ -4520,7 +4520,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "bincode",
  "flume",
@@ -4537,7 +4537,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "hashbrown",
  "keyed-set",
@@ -4551,7 +4551,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -4568,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "async-trait",
  "flume",
@@ -4591,7 +4591,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4616,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "async-trait",
  "socket2 0.5.7",
@@ -4633,7 +4633,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4660,7 +4660,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "async-trait",
  "socket2 0.5.7",
@@ -4679,7 +4679,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "async-trait",
  "nix",
@@ -4697,7 +4697,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4717,7 +4717,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4728,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-rest"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "anyhow",
  "async-std",
@@ -4778,7 +4778,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "git-version",
  "libloading",
@@ -4794,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "const_format",
  "rand 0.8.5",
@@ -4808,7 +4808,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "anyhow",
 ]
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "lazy_static",
  "ron",
@@ -4829,7 +4829,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "event-listener 5.3.1",
  "futures",
@@ -4842,7 +4842,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "futures",
  "tokio",
@@ -4855,7 +4855,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "1.0.0-dev"
-source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c040abdb12d1afccb90131d9a9712e38437426d7"
 dependencies = [
  "async-trait",
  "const_format",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1861,6 +1861,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
 name = "libc"
 version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3903,12 +3909,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "unwrap-infallible"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "151ac09978d3c2862c4e39b557f4eceee2cc72150bc4cb4f16abf061b6e381fb"
-
-[[package]]
 name = "unzip-n"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4383,7 +4383,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4410,7 +4410,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "uhlc",
- "unwrap-infallible",
  "vec_map",
  "zenoh-buffers",
  "zenoh-codec",
@@ -4452,7 +4451,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "zenoh-collections",
 ]
@@ -4460,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "tracing",
  "uhlc",
@@ -4471,12 +4470,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 
 [[package]]
 name = "zenoh-config"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "json5",
  "num_cpus",
@@ -4497,7 +4496,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -4508,7 +4507,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "aes 0.8.4",
  "hmac 0.12.1",
@@ -4521,11 +4520,12 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "bincode",
  "flume",
  "futures",
+ "leb128",
  "serde",
  "tokio",
  "tracing",
@@ -4537,7 +4537,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "hashbrown",
  "keyed-set",
@@ -4551,7 +4551,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -4568,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "async-trait",
  "flume",
@@ -4591,7 +4591,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4616,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "async-trait",
  "socket2 0.5.7",
@@ -4633,7 +4633,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4660,7 +4660,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "async-trait",
  "socket2 0.5.7",
@@ -4679,7 +4679,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "async-trait",
  "nix",
@@ -4697,7 +4697,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4717,7 +4717,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4728,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-rest"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "anyhow",
  "async-std",
@@ -4778,7 +4778,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "git-version",
  "libloading",
@@ -4794,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "const_format",
  "rand 0.8.5",
@@ -4808,7 +4808,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "anyhow",
 ]
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "lazy_static",
  "ron",
@@ -4829,7 +4829,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "event-listener 5.3.1",
  "futures",
@@ -4842,7 +4842,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "futures",
  "tokio",
@@ -4855,7 +4855,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e79c80063f3d6b176d9bbef5f6d0cad9ead27b01"
+source = "git+https://github.com/ZettaScaleLabs/zenoh.git?branch=serialization_ext2#2acefcd4aa04d022aac63d8c1efe7beed852d2a1"
 dependencies = [
  "async-trait",
  "const_format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,17 +42,17 @@ serde = "1.0.154"
 serde_json = "1.0.114"
 tokio = { version = "1.35.1", default-features = false } # Default features are disabled due to some crates' requirements
 tracing = "0.1"
-zenoh = { version = "1.0.0-dev", git = "https://github.com/ZettaScaleLabs/zenoh.git", branch = "serialization_ext2", features = [
+zenoh = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", features = [
   "plugins",
   "unstable",
 ] }
-zenoh-config = { version = "1.0.0-dev", git = "https://github.com/ZettaScaleLabs/zenoh.git", branch = "serialization_ext2", default-features = false }
-zenoh-ext = { version = "1.0.0-dev", git = "https://github.com/ZettaScaleLabs/zenoh.git", branch = "serialization_ext2", features = [
+zenoh-config = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false }
+zenoh-ext = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", features = [
   "unstable",
 ] }
 zenoh-plugin-ros2dds = { version = "1.0.0-dev", path = "zenoh-plugin-ros2dds/", default-features = false }
-zenoh-plugin-rest = { version = "1.0.0-dev", git = "https://github.com/ZettaScaleLabs/zenoh.git", branch = "serialization_ext2", default-features = false, features=["static_plugin"]}
-zenoh-plugin-trait = { version = "1.0.0-dev", git = "https://github.com/ZettaScaleLabs/zenoh.git", branch = "serialization_ext2", default-features = false }
+zenoh-plugin-rest = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false, features=["static_plugin"]}
+zenoh-plugin-trait = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false }
 
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,19 +42,18 @@ serde = "1.0.154"
 serde_json = "1.0.114"
 tokio = { version = "1.35.1", default-features = false } # Default features are disabled due to some crates' requirements
 tracing = "0.1"
-zenoh = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", features = [
-  "internal",
-  "internal_config",
-  "unstable",
+zenoh = { version = "1.0.0-dev", git = "https://github.com/ZettaScaleLabs/zenoh.git", branch = "serialization_ext2", features = [
   "plugins",
-] }
-zenoh-config = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false }
-zenoh-ext = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", features = [
   "unstable",
 ] }
-zenoh-plugin-rest = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false, features=["static_plugin"]}
+zenoh-config = { version = "1.0.0-dev", git = "https://github.com/ZettaScaleLabs/zenoh.git", branch = "serialization_ext2", default-features = false }
+zenoh-ext = { version = "1.0.0-dev", git = "https://github.com/ZettaScaleLabs/zenoh.git", branch = "serialization_ext2", features = [
+  "unstable",
+] }
 zenoh-plugin-ros2dds = { version = "1.0.0-dev", path = "zenoh-plugin-ros2dds/", default-features = false }
-zenoh-plugin-trait = { version = "1.0.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false }
+zenoh-plugin-rest = { version = "1.0.0-dev", git = "https://github.com/ZettaScaleLabs/zenoh.git", branch = "serialization_ext2", default-features = false, features=["static_plugin"]}
+zenoh-plugin-trait = { version = "1.0.0-dev", git = "https://github.com/ZettaScaleLabs/zenoh.git", branch = "serialization_ext2", default-features = false }
+
 
 [profile.release]
 codegen-units = 1

--- a/zenoh-plugin-ros2dds/src/discovered_entities.rs
+++ b/zenoh-plugin-ros2dds/src/discovered_entities.rs
@@ -453,10 +453,10 @@ impl DiscoveredEntities {
         match self.get_entity_json_value(entity_ref) {
             Ok(Some(v)) => {
                 let admin_keyexpr = admin_keyexpr_prefix / key_expr;
-                match ZBytes::try_from(v) {
-                    Ok(payload) => {
+                match serde_json::to_vec(&v) {
+                    Ok(bytes) => {
                         if let Err(e) = query
-                            .reply(admin_keyexpr, payload)
+                            .reply(admin_keyexpr, ZBytes::from(bytes))
                             .encoding(Encoding::APPLICATION_JSON)
                             .await
                         {

--- a/zenoh-plugin-ros2dds/src/lib.rs
+++ b/zenoh-plugin-ros2dds/src/lib.rs
@@ -601,8 +601,8 @@ impl ROS2PluginRuntime {
     async fn send_admin_reply(&self, query: &Query, key_expr: &keyexpr, admin_ref: &AdminRef) {
         let z_bytes: ZBytes = match admin_ref {
             AdminRef::Version => match serde_json::to_value(ROS2Plugin::PLUGIN_LONG_VERSION) {
-                Ok(v) => match ZBytes::try_from(v) {
-                    Ok(value) => value,
+                Ok(v) => match serde_json::to_vec(&v) {
+                    Ok(bytes) => ZBytes::from(bytes),
                     Err(e) => {
                         tracing::warn!("Error transforming JSON to ZBytes: {}", e);
                         return;
@@ -614,8 +614,8 @@ impl ROS2PluginRuntime {
                 }
             },
             AdminRef::Config => match serde_json::to_value(&*self.config) {
-                Ok(v) => match ZBytes::try_from(v) {
-                    Ok(value) => value,
+                Ok(v) => match serde_json::to_vec(&v) {
+                    Ok(bytes) => ZBytes::from(bytes),
                     Err(e) => {
                         tracing::warn!("Error transforming JSON to ZBytes: {}", e);
                         return;

--- a/zenoh-plugin-ros2dds/src/ros2_utils.rs
+++ b/zenoh-plugin-ros2dds/src/ros2_utils.rs
@@ -13,7 +13,6 @@
 //
 
 use std::{
-    collections::HashMap,
     env::VarError,
     sync::atomic::{AtomicU32, Ordering},
 };
@@ -220,20 +219,14 @@ impl CddsRequestHeader {
     }
 
     pub fn as_attachment(&self) -> ZBytes {
-        let mut hashmap = HashMap::new();
-
         // concat header + endianness flag
         let mut buf = [0u8; 17];
         buf[0..16].copy_from_slice(&self.header);
         buf[16] = self.is_little_endian as u8;
 
-        hashmap.insert(ATTACHMENT_KEY_REQUEST_HEADER, buf);
-
         let mut writer = ZBytes::writer();
-        for (k, v) in hashmap.iter() {
-            writer.append(ZBytes::from(k));
-            writer.append(ZBytes::from(v));
-        }
+        writer.append(ZBytes::from(ATTACHMENT_KEY_REQUEST_HEADER));
+        writer.append(ZBytes::from(buf));
         writer.finish()
     }
 }
@@ -242,23 +235,34 @@ impl TryFrom<&ZBytes> for CddsRequestHeader {
     type Error = ZError;
 
     fn try_from(value: &ZBytes) -> Result<Self, Self::Error> {
-        let hashmap: HashMap<[u8; 3], [u8; 17]> = zenoh_ext::z_deserialize(value).unwrap();
+        let bytes = value.to_bytes();
 
-        match hashmap.get(&ATTACHMENT_KEY_REQUEST_HEADER) {
-            Some(buf) => {
-                if buf.len() == 17 {
-                    let header: [u8; 16] = buf[0..16]
-                        .try_into()
-                        .expect("Shouldn't happen: buf is 17 bytes");
-                    Ok(CddsRequestHeader {
-                        header,
-                        is_little_endian: buf[16] != 0,
-                    })
-                } else {
-                    bail!("Attachment 'header' is not 16 bytes: {buf:02x?}")
-                }
+        let header = match bytes.get(0..ATTACHMENT_KEY_REQUEST_HEADER.len()) {
+            Some(header) => header,
+            None => bail!("No 'key request header' bytes found in attachment"),
+        };
+
+        if header != ATTACHMENT_KEY_REQUEST_HEADER {
+            bail!(
+                "Initial {:?} bytes do not match ATTACHMENT_KEY_REQUEST_HEADER",
+                ATTACHMENT_KEY_REQUEST_HEADER.len()
+            )
+        }
+
+        if let Some(buf) = bytes.get(ATTACHMENT_KEY_REQUEST_HEADER.len()..) {
+            if buf.len() == 17 {
+                let header: [u8; 16] = buf[0..16]
+                    .try_into()
+                    .expect("Shouldn't happen: buf is 17 bytes");
+                Ok(CddsRequestHeader {
+                    header,
+                    is_little_endian: buf[16] != 0,
+                })
+            } else {
+                bail!("Attachment 'header' is not 16 bytes: {buf:02x?}")
             }
-            None => bail!("No 'header' key found in Attachment"),
+        } else {
+            bail!("Could not Read Remaining Attachment Buffer")
         }
     }
 }

--- a/zenoh-plugin-ros2dds/src/route_subscriber.rs
+++ b/zenoh-plugin-ros2dds/src/route_subscriber.rs
@@ -357,7 +357,7 @@ fn route_zenoh_message_to_dds(s: Sample, ros2_name: &str, data_writer: dds_entit
     }
 
     unsafe {
-        let bs = s.payload().into();
+        let bs = s.payload().to_bytes().to_vec();
         // As per the Vec documentation (see https://doc.rust-lang.org/std/vec/struct.Vec.html#method.into_raw_parts)
         // the only way to correctly releasing it is to create a vec using from_raw_parts
         // and then have its destructor do the cleanup.

--- a/zenoh-plugin-ros2dds/src/routes_mgr.rs
+++ b/zenoh-plugin-ros2dds/src/routes_mgr.rs
@@ -792,10 +792,10 @@ impl<'a> RoutesMgr {
         match self.get_entity_json_value(route_ref) {
             Ok(Some(v)) => {
                 let admin_keyexpr = &self.admin_prefix / key_expr;
-                match ZBytes::try_from(v) {
-                    Ok(payload) => {
+                match serde_json::to_vec(&v) {
+                    Ok(bytes) => {
                         if let Err(e) = query
-                            .reply(admin_keyexpr, payload)
+                            .reply(admin_keyexpr, ZBytes::from(bytes))
                             .encoding(Encoding::APPLICATION_JSON)
                             .await
                         {


### PR DESCRIPTION
Porting Ros2dds plugin over to new Serialization API
Tracking issue
https://github.com/eclipse-zenoh/zenoh/issues/1474

Note: update Dependencies when https://github.com/eclipse-zenoh/zenoh/pull/1473 is merged