### PR TITLE
Fix sertype lookup failed warning

### DIFF
--- a/zenoh-plugin-ros2dds/src/route_publisher.rs
+++ b/zenoh-plugin-ros2dds/src/route_publisher.rs
@@ -274,6 +274,7 @@ impl RoutePublisher {
                         }
                     }
                 })
+                .undeclare_on_drop(true)
                 .await
                 .map_err(|e| format!("Failed to listen of matching status changes: {e}",))?
         };

--- a/zenoh-plugin-ros2dds/src/route_service_cli.rs
+++ b/zenoh-plugin-ros2dds/src/route_service_cli.rs
@@ -264,7 +264,7 @@ impl RouteServiceCli {
         let rep_writer = self.rep_writer.swap(DDS_ENTITY_NULL, Ordering::Relaxed);
         if rep_writer != DDS_ENTITY_NULL {
             // remove writer's GID from ros_discovery_info message
-            match get_guid(&req_reader) {
+            match get_guid(&rep_writer) {
                 Ok(gid) => self.context.ros_discovery_mgr.remove_dds_writer(gid),
                 Err(e) => tracing::warn!("{self}: {e}"),
             }

--- a/zenoh-plugin-ros2dds/src/route_service_srv.rs
+++ b/zenoh-plugin-ros2dds/src/route_service_srv.rs
@@ -255,6 +255,7 @@ impl RouteServiceSrv {
                         req_writer,
                     )
                 })
+                .undeclare_on_drop(true)
                 .await
                 .map_err(|e| {
                     format!(

--- a/zenoh-plugin-ros2dds/src/route_subscriber.rs
+++ b/zenoh-plugin-ros2dds/src/route_subscriber.rs
@@ -192,6 +192,7 @@ impl RouteSubscriber {
                 .zsession
                 .declare_subscriber(&self.zenoh_key_expr)
                 .callback(subscriber_callback)
+                .undeclare_on_drop(true)
                 .allowed_origin(Locality::Remote) // Allow only remote publications to avoid loops
                 .querying()
                 .query_timeout(self.queries_timeout)
@@ -206,6 +207,7 @@ impl RouteSubscriber {
                 .zsession
                 .declare_subscriber(&self.zenoh_key_expr)
                 .callback(subscriber_callback)
+                .undeclare_on_drop(true)
                 .allowed_origin(Locality::Remote) // Allow only remote publications to avoid loops
                 .await
                 .map_err(|e| format!("{self}: failed to create Subscriber: {e}"))?;


### PR DESCRIPTION
Added undeclare_on_drop(true) to Zenoh entity construction to ensure subscriptions are automatically undeclared when dropped.

Fixes #278.