### PR TITLE
fix systemctl falling back to defaultTimeoutStopSec shutdown and use sigterm

### DIFF
--- a/zenoh-bridge-ros2dds/.service/zenoh-bridge-ros2dds.service
+++ b/zenoh-bridge-ros2dds/.service/zenoh-bridge-ros2dds.service
@@ -9,7 +9,7 @@ Wants=network-online.target
 Type=simple
 Environment=RUST_LOG=info
 ExecStart =+/usr/bin/zenoh-bridge-ros2dds -c /etc/zenoh-bridge-ros2dds/conf.json5
-KillMode=mixed
+KillMode=control-group
 KillSignal=SIGINT
 RestartKillSignal=SIGINT
 Restart=on-failure


### PR DESCRIPTION
While shutting down the service, systemd would timeout and send SIGTERM after 90sec (default parameter value of systemd)

Following is the quote from the man page of systemd.kill

> If set to control-group, all remaining processes in the control group of this unit will be killed on unit stop (for services: after the stop command is executed, as configured with ExecStop=). If set to mixed, the SIGTERM signal (see below) is sent to the main process while the subsequent SIGKILL signal (see below) is sent to all remaining processes of the unit's control group. 

https://www.freedesktop.org/software/systemd/man/latest/systemd.kill.html#

Setting KillMode doesn't raise any error in the shutting down process.