### PR TITLE
Fix invalid warning when $ROS_AUTOMATIC_DISCOVERY_RANGE is not defined

### DIFF
--- a/zenoh-plugin-ros2dds/src/config.rs
+++ b/zenoh-plugin-ros2dds/src/config.rs
@@ -933,7 +933,7 @@ mod tests {
         assert_eq!(__required__, None);
     }
 
-    #[test_case("{}", Some(RosAutomaticDiscoveryRange::Subnet); "Empty tests")]
+    #[test_case("{}", None; "Empty tests")]
     #[test_case(r#"{"ros_automatic_discovery_range": "SUBNET"}"#, Some(RosAutomaticDiscoveryRange::Subnet); "SUBNET tests")]
     #[test_case(r#"{"ros_automatic_discovery_range": "LOCALHOST"}"#, Some(RosAutomaticDiscoveryRange::Localhost); "LOCALHOST tests")]
     #[test_case(r#"{"ros_automatic_discovery_range": "OFF"}"#, Some(RosAutomaticDiscoveryRange::Off); "OFF tests")]

--- a/zenoh-plugin-ros2dds/src/config.rs
+++ b/zenoh-plugin-ros2dds/src/config.rs
@@ -493,7 +493,9 @@ fn default_automatic_discovery_range() -> Option<RosAutomaticDiscoveryRange> {
         Ok("OFF") => Some(RosAutomaticDiscoveryRange::Localhost),
         Ok("SYSTEM_DEFAULT") => Some(RosAutomaticDiscoveryRange::SystemDefault),
         Ok(value) => {
-            warn!(r#"Invalid value for environment variable ROS_AUTOMATIC_DISCOVERY_RANGE ("{value}"). Using "SUBNET" instead "#);
+            warn!(
+                r#"Invalid value for environment variable ROS_AUTOMATIC_DISCOVERY_RANGE ("{value}"). Using "SUBNET" instead "#
+            );
             Some(RosAutomaticDiscoveryRange::Subnet)
         }
         Err(_) => None,
@@ -525,7 +527,7 @@ where
     let peers: String = Deserialize::deserialize(deserializer).unwrap();
     let mut peer_list: Vec<String> = Vec::new();
     for peer in peers.split(';') {
-        if peer != "" {
+        if !peer.is_empty() {
             peer_list.push(peer.to_owned());
         }
     }

--- a/zenoh-plugin-ros2dds/src/lib.rs
+++ b/zenoh-plugin-ros2dds/src/lib.rs
@@ -331,7 +331,7 @@ pub async fn run(runtime: Runtime, config: Config) {
             (Some(RosAutomaticDiscoveryRange::Localhost), None)
         } else {
             (
-                config.ros_automatic_discovery_range.clone(),
+                config.ros_automatic_discovery_range,
                 config.ros_static_peers.clone(),
             )
         };


### PR DESCRIPTION
Following #311 , on Humble the following warning is logged when `$ROS_AUTOMATIC_DISCOVERY_RANGE` environment variable is not set:
`WARN tokio-runtime-worker ThreadId(09) zenoh_plugin_ros2dds: ROS_AUTOMATIC_DISCOVERY_RANGE will be ignored since it's not supported before ROS 2 Iron`

The cause is [Config::default_automatic_discovery_range()](https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/blob/7b4b224f58aa704d0ab27a18f152b9a1919dfc4a/zenoh-plugin-ros2dds/src/config.rs#L493) setting the value to `Some(RosAutomaticDiscoveryRange::Subnet)` if the environment variable is not defined.

This PR fixes this.