### PR TITLE
Fix NodeInfo update after Reader discovery

### DIFF
--- a/zenoh-plugin-ros2dds/src/discovered_entities.rs
+++ b/zenoh-plugin-ros2dds/src/discovered_entities.rs
@@ -213,7 +213,7 @@ impl DiscoveredEntities {
                 {
                     // update the NodeInfo with this Reader's info
                     node.undiscovered_reader.remove(i);
-                    event = node.update_with_writer(&reader);
+                    event = node.update_with_reader(&reader);
                     break;
                 }
             }


### PR DESCRIPTION
Reviewing the code, I spotted an inconsistency in code reacting to the discovery of a DDS Reader and updating the NodeInfo object:
`node.update_with_writer(&reader);` was called instead of 
`node.update_with_reader(&reader);`

AFAICT this bug was only affecting the view of what has been discovered for a Node in the admin space, and only in the case the bridge received the `ros_discovery_info` message declaring the Reader before discovering this DDS Reader.
This case probably rarely occurs.