### PR TITLE
Add CI for checking markdown format.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,15 @@ jobs:
       # Note that we limit only one test item tested at the same time to avoid the confliction between bridges
       run: "source /opt/ros/jazzy/setup.bash && cd zenoh-test-ros2dds && cargo test --verbose -- --test-threads=1"
 
+  markdown_lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v18
+        with:
+          config: '.markdownlint.yaml'
+          globs: '**/README.md'
+
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged
   # from branches where specific status checks have passed. These checks are
@@ -146,7 +155,7 @@ jobs:
   ci:
     name: CI status checks
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, system_tests_with_ros2_humble, system_tests_with_ros2_jazzy, markdown_lint]
     if: always()
     steps:
       - name: Check whether all jobs pass

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,6 @@
+{
+  "MD013": false, # Line length limitation
+  "MD033": false, # Enable Inline HTML
+  "MD041": false, # Allow first line heading
+  "MD045": false, # Allow Images have no alternate text
+}

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ DDS support is provided by the [cyclors crate](https://crates.io/crates/cyclors)
 To allow multiple versions of the ```cyclors``` crate to be loaded at the same time the symbols within the crate can be prefixed with the crate version. The optional ```prefix_symbols``` feature can be used to build the ROS2 plugin with prefixed DDS library symbols. e.g.
 
 ```bash
-$ cargo build --features prefix_symbols
+cargo build --features prefix_symbols
 ```
 
 **Note:** The ```prefix_symbols``` feature cannot be used at the same time as the ```dds_shm``` feature.


### PR DESCRIPTION
As https://github.com/eclipse-zenoh/zenoh/issues/1666, fix the README.md format and update CI.