### PR TITLE
actions/get_result has a different default timeout.

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -125,8 +125,9 @@
 
       ////
       //// queries_timeout: Timeouts configuration for various Zenoh queries.
-      ////                  Each field is optional. If not set, the 'default' timeout (5.0 seconds by default) applies to all queries.
-      ////                  Note that actions/get_result is the special case, and we need a larger timeout (300.0 seconds by default).
+      ////                  Each field is optional. If not set, the 'default' timeout (5.0 seconds by default) applies to all queries,
+      ////                  except for actions' get_result that is by default configured with a larget timeout (300.0 seconds)
+      ////                  to support actions that last a long time.
       ////                  Refer to https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/issues/369#issuecomment-2563725619
       ////                  Each value can be either a float in seconds that will apply as a timeout to all queries,
       ////                  either a list of strings with format "<regex>=<float>" where:

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -135,7 +135,7 @@
       ////                      - "float" is the timeout in seconds
       // queries_timeout: {
       //   //// default timeout that will apply to all query, except the ones specified below
-      //   //// in 'transient_local_subscribers', 'services' and 'actions' (except get_result)
+      //   //// in 'transient_local_subscribers', 'services' and 'actions'
       //   default: 5.0,
       //   //// timeouts for TRANSIENT_LOCAL subscriber when querying publishers for historical publications
       //   transient_local_subscribers: 1.0,
@@ -145,7 +145,7 @@
       //   actions: {
       //     send_goal: 1.0,
       //     cancel_goal: 1.0,
-      //     get_result: [".*long_mission=3600", ".*short_action=10.0"],
+      //     get_result: [".*long_mission=3600", ".*short_action=10.0", ".*=300"],
       //   }
       // },
 

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -126,13 +126,15 @@
       ////
       //// queries_timeout: Timeouts configuration for various Zenoh queries.
       ////                  Each field is optional. If not set, the 'default' timeout (5.0 seconds by default) applies to all queries.
+      ////                  Note that actions/get_result is the special case, and we need a larger timeout (300.0 seconds by default).
+      ////                  Refer to https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/issues/369#issuecomment-2563725619
       ////                  Each value can be either a float in seconds that will apply as a timeout to all queries,
       ////                  either a list of strings with format "<regex>=<float>" where:
       ////                      - "regex" is a regular expression matching an interface name
       ////                      - "float" is the timeout in seconds
       // queries_timeout: {
       //   //// default timeout that will apply to all query, except the ones specified below
-      //   //// in 'transient_local_subscribers', 'services' and 'actions'
+      //   //// in 'transient_local_subscribers', 'services' and 'actions' (except get_result)
       //   default: 5.0,
       //   //// timeouts for TRANSIENT_LOCAL subscriber when querying publishers for historical publications
       //   transient_local_subscribers: 1.0,

--- a/zenoh-plugin-ros2dds/src/config.rs
+++ b/zenoh-plugin-ros2dds/src/config.rs
@@ -401,11 +401,11 @@ fn default_domain() -> u32 {
 }
 
 fn default_queries_timeout() -> Option<QueriesTimeouts> {
-    Some(QueriesTimeouts{
+    Some(QueriesTimeouts {
         default: default_queries_timeout_default(),
         transient_local_subscribers: Vec::new(),
         services: Vec::new(),
-        actions: default_actions_timeout()
+        actions: default_actions_timeout(),
     })
 }
 


### PR DESCRIPTION
As described https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/issues/369, it would be better to have a different default timeout for `get_result` service in ROS 2 action.

Here are some questions:
1. I set the timeout to 300 seconds, but is that enough for most user cases?
2. Should we separate the `actions/get_result` from the `queries_timeout` in the configuration file?