### PR TITLE
Fixed systemctl command handling

### DIFF
--- a/zenoh-bridge-ros2dds/.deb/postinst
+++ b/zenoh-bridge-ros2dds/.deb/postinst
@@ -20,14 +20,15 @@ set -e
 
 case "$1" in
     configure)
-        if ! command -v systemctl &> /dev/null
-        then
-            echo "WARNING: 'systemctl' not found - cannot install zenoh-bridge-ros2dds as a service."
-            exit 0
-        fi
+	SYSTEMCTL_CMD=$(command -v systemctl)
+	if [ -z "$SYSTEMCTL_CMD" ]; then
+		echo "WARNING: 'systemctl' not found - cannot install zenoh-bridge-ros2dds as a service."
+		exit 0
+	fi
+	echo "Found $SYSTEMCTL_CMD"
         id -u zenoh-bridge-ros2dds &> /dev/null || useradd -r -s /bin/false zenoh-bridge-ros2dds
-        systemctl daemon-reload
-        systemctl disable zenoh-bridge-ros2dds
+        "$SYSTEMCTL_CMD" daemon-reload
+        "$SYSTEMCTL_CMD" disable zenoh-bridge-ros2dds
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
# Fixed systemctl command handling

I got following warning while installing `zenoh-bridge-ros2dds`

```bash
$ sudo apt-get install --reinstall zenoh-bridge-ros2dds 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
0 upgraded, 0 newly installed, 1 reinstalled, 0 to remove and 8 not upgraded.
Need to get 5,468 kB of archives.
After this operation, 0 B of additional disk space will be used.
Get:1 https://download.eclipse.org/zenoh/debian-repo  zenoh-bridge-ros2dds 1.2.1 [5,468 kB]
Fetched 5,468 kB in 16s (333 kB/s)                                                                                                                                          
(Reading database ... 413532 files and directories currently installed.)
Preparing to unpack .../zenoh-bridge-ros2dds_1.2.1_amd64.deb ...
Unpacking zenoh-bridge-ros2dds (1.2.1) over (1.2.1) ...
Setting up zenoh-bridge-ros2dds (1.2.1) ...
WARNING: 'systemctl' not found - cannot install zenoh-bridge-ros2dds as a service.
/usr/bin/systemctl
```

I believe the handling of `command` output is not working on different bash. I tried to reproduce the issue using simple bash scripts:

## test1.sh
```bash
#!/bin/sh
if ! command -v systemctl &> /dev/null
then
	echo "WARNING: 'systemctl' not found - cannot install zenoh-bridge-ros2dds as a service."
	exit 0
fi
echo "Found"
```
which produced following output:
```bash
$ ./test1.sh 
WARNING: 'systemctl' not found - cannot install zenoh-bridge-ros2dds as a service.
/usr/bin/systemctl
```
I believe the more proper way of using the `command` can be following:

## test2.sh
```bash
#!/bin/sh
SYSTEMCTL_CMD=$(command -v systemctl)
if [ -z "$SYSTEMCTL_CMD" ]; then
	echo "systemctl command not be found"
	exit 0
fi
echo "Found $SYSTEMCTL_CMD"
```
which produces following output:
```bash
$ ./test2.sh 
Found /usr/bin/systemctl
```
This PR incorporates the same.
Note: Fixes #139 
