### PR TITLE
CI: fix tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,9 @@ jobs:
     - name: Install ACL
       run: sudo apt-get -y install libacl1-dev
 
+    - name: Copy rust-toolchain.toml and Cargo.lock to zenoh-test-ros2dds
+      shell: bash
+      run: 'cp rust-toolchain.toml Cargo.lock zenoh-test-ros2dds/'
     - name: Code format check
       shell: bash
       run: 'source /opt/ros/jazzy/setup.bash && cd zenoh-test-ros2dds && cargo fmt --check -- --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,9 @@ jobs:
     - name: Install ACL
       run: sudo apt-get -y install libacl1-dev
 
+    - name: Copy rust-toolchain.toml and Cargo.lock to zenoh-test-ros2dds
+      shell: bash
+      run: 'cp rust-toolchain.toml Cargo.lock zenoh-test-ros2dds/'
     - name: Code format check
       shell: bash
       run: 'source /opt/ros/humble/setup.bash && cd zenoh-test-ros2dds && cargo fmt --check -- --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate"'


### PR DESCRIPTION
Since recent bump of some dependencies, the test were failing with such error:
```log
error: package `zerofrom v0.1.6` cannot be built because it requires rustc 1.81 or newer, while the currently active rustc version is 1.75.0
Either upgrade to rustc 1.81 or newer, or use
cargo update zerofrom@0.1.6 --precise ver
where `ver` is the latest version of `zerofrom` supporting rustc 1.75.0
```

This PR makes sure that in CI the tests are built with the same Rust compiler and pinned dependencies than the plugin.
For this, it just copies the `Cargo.lock` and `rust-toolchain.toml` from root dir.