### PR TITLE
fix: update bump-deps-pattern to zenoh.*

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       version: ${{ inputs.version }}
       branch: ${{ inputs.branch }}
       bump-deps-version: ${{ inputs.zenoh-version }}
-      bump-deps-pattern: ${{ inputs.zenoh-version && 'zenoh.*' || '^$' }}
+      bump-deps-pattern: 'zenoh.*'
       bump-deps-branch: ${{ inputs.zenoh-version && format('release/{0}', inputs.zenoh-version) || '' }}
     secrets: inherit
 


### PR DESCRIPTION
Should fix scheduled release workflow to work correctly: https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/actions/runs/13935990179