### PR TITLE
Don't assign the specific Zenoh version in zenoh-test-ros2dds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,10 @@ jobs:
     - name: Copy rust-toolchain.toml and Cargo.lock to zenoh-test-ros2dds
       shell: bash
       run: 'cp rust-toolchain.toml Cargo.lock zenoh-test-ros2dds/'
+    # We need this to align the Zenoh version in zenoh-test-ros2dds with zenoh-plugin-ros2dds
+    - name: Align zenoh version in zenoh-test-ros2dds
+      shell: bash
+      run: 'sudo apt-get -y install python3-tomlkit && cd zenoh-test-ros2dds && python align_zenoh.py'
     - name: Code format check
       shell: bash
       run: 'source /opt/ros/humble/setup.bash && cd zenoh-test-ros2dds && cargo fmt --check -- --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate"'
@@ -150,6 +154,10 @@ jobs:
     - name: Copy rust-toolchain.toml and Cargo.lock to zenoh-test-ros2dds
       shell: bash
       run: 'cp rust-toolchain.toml Cargo.lock zenoh-test-ros2dds/'
+    # We need this to align the Zenoh version in zenoh-test-ros2dds with zenoh-plugin-ros2dds
+    - name: Align zenoh version in zenoh-test-ros2dds
+      shell: bash
+      run: 'sudo apt-get -y install python3-tomlkit && cd zenoh-test-ros2dds && python align_zenoh.py'
     - name: Code format check
       shell: bash
       run: 'source /opt/ros/jazzy/setup.bash && cd zenoh-test-ros2dds && cargo fmt --check -- --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
     # We need this to align the Zenoh version in zenoh-test-ros2dds with zenoh-plugin-ros2dds
     - name: Align zenoh version in zenoh-test-ros2dds
       shell: bash
-      run: 'sudo apt-get -y install python3-tomlkit && cd zenoh-test-ros2dds && python align_zenoh.py'
+      run: 'sudo apt-get -y install python3-tomlkit && cd zenoh-test-ros2dds && python3 align_zenoh.py'
     - name: Code format check
       shell: bash
       run: 'source /opt/ros/humble/setup.bash && cd zenoh-test-ros2dds && cargo fmt --check -- --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate"'
@@ -157,7 +157,7 @@ jobs:
     # We need this to align the Zenoh version in zenoh-test-ros2dds with zenoh-plugin-ros2dds
     - name: Align zenoh version in zenoh-test-ros2dds
       shell: bash
-      run: 'sudo apt-get -y install python3-tomlkit && cd zenoh-test-ros2dds && python align_zenoh.py'
+      run: 'sudo apt-get -y install python3-tomlkit && cd zenoh-test-ros2dds && python3 align_zenoh.py'
     - name: Code format check
       shell: bash
       run: 'source /opt/ros/jazzy/setup.bash && cd zenoh-test-ros2dds && cargo fmt --check -- --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate"'

--- a/zenoh-test-ros2dds/Cargo.toml
+++ b/zenoh-test-ros2dds/Cargo.toml
@@ -23,13 +23,11 @@ serde = "1.0.219"
 serde_derive = "1.0.219"
 serde_json = "1.0.142"
 tokio = { version = "1.47.1", default-features = false } # Default features are disabled due to some crates' requirements
-# We don't assign any Zenoh version here, and it will not be limited to a specific version.
-# This will force us to use the same Zenoh version as zenoh-plugin-ros2dds.
-zenoh = { version = "*", features = [
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", features = [
   "plugins",
   "unstable",
 ] }
-zenoh-config = { version = "*", default-features = false }
+zenoh-config = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false }
 zenoh-plugin-ros2dds = { path = "../zenoh-plugin-ros2dds/", default-features = false }
 
 # We need an empty workspace to avoid being viewed as a part of zenoh-plugin-ros2dds

--- a/zenoh-test-ros2dds/Cargo.toml
+++ b/zenoh-test-ros2dds/Cargo.toml
@@ -23,11 +23,13 @@ serde = "1.0.219"
 serde_derive = "1.0.219"
 serde_json = "1.0.142"
 tokio = { version = "1.47.1", default-features = false } # Default features are disabled due to some crates' requirements
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", features = [
+# We don't assign any Zenoh version here, and it will not be limited to a specific version.
+# This will force us to use the same Zenoh version as zenoh-plugin-ros2dds.
+zenoh = { version = "*", features = [
   "plugins",
   "unstable",
 ] }
-zenoh-config = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false }
+zenoh-config = { version = "*", default-features = false }
 zenoh-plugin-ros2dds = { path = "../zenoh-plugin-ros2dds/", default-features = false }
 
 # We need an empty workspace to avoid being viewed as a part of zenoh-plugin-ros2dds

--- a/zenoh-test-ros2dds/align_zenoh.py
+++ b/zenoh-test-ros2dds/align_zenoh.py
@@ -14,4 +14,5 @@ for dep_name in ["zenoh", "zenoh-config"]:
     target_doc["dependencies"][dep_name] = source_dep
 
 # Write changes back to target
+print(target_doc)
 target_path.write_text(tomlkit.dumps(target_doc))

--- a/zenoh-test-ros2dds/align_zenoh.py
+++ b/zenoh-test-ros2dds/align_zenoh.py
@@ -1,0 +1,17 @@
+import tomlkit
+from pathlib import Path
+
+target_path = Path("Cargo.toml")
+source_path = Path("../Cargo.toml")
+
+# Read the file
+target_doc = tomlkit.parse(target_path.read_text())
+source_doc = tomlkit.parse(source_path.read_text())
+
+# Get from source and apply to target
+for dep_name in ["zenoh", "zenoh-config"]:
+    source_dep = source_doc["workspace"]["dependencies"][dep_name]
+    target_doc["dependencies"][dep_name] = source_dep
+
+# Write changes back to target
+target_path.write_text(tomlkit.dumps(target_doc))


### PR DESCRIPTION
In the Zenoh release, it's required to test on a specific Zenoh version.
However, we built the `zenoh-test-ros2dds` with the Zenoh main branch, which caused the version mismatch between `zenoh-plugin-ros2dds` and `zenoh-test-ros2dds`.
Here is the build failure: https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/actions/runs/16924085354/job/47956307055

~~To resolve the issue, we don't assign any Zenoh version in the `zenoh-test-ros2dds`, and cargo will choose the version we specify in the release process.~~

We use a Python script to align the Zenoh version between two crates.
