### PR TITLE
From PublicationCache to AdvancedPublisher and AdvancedSubscriber

### DIFF
--- a/zenoh-plugin-ros2dds/src/lib.rs
+++ b/zenoh-plugin-ros2dds/src/lib.rs
@@ -516,7 +516,7 @@ impl ROS2PluginRuntime {
                                     (None, SampleKind::Put) => {
                                         tracing::info!("New ROS 2 bridge detected: {}", zenoh_id);
                                         // make each routes for a TRANSIENT_LOCAL Subscriber to query historical publications from this new plugin
-                                        routes_mgr.query_all_historical_publications(zenoh_id).await;
+                                        // routes_mgr.query_all_historical_publications(zenoh_id).await;
                                     }
                                     // New remote bridge left
                                     (None, SampleKind::Delete) => tracing::info!("Remote ROS 2 bridge left: {}", zenoh_id),

--- a/zenoh-plugin-ros2dds/src/lib.rs
+++ b/zenoh-plugin-ros2dds/src/lib.rs
@@ -515,8 +515,6 @@ impl ROS2PluginRuntime {
                                     // New remote bridge detected
                                     (None, SampleKind::Put) => {
                                         tracing::info!("New ROS 2 bridge detected: {}", zenoh_id);
-                                        // make each routes for a TRANSIENT_LOCAL Subscriber to query historical publications from this new plugin
-                                        // routes_mgr.query_all_historical_publications(zenoh_id).await;
                                     }
                                     // New remote bridge left
                                     (None, SampleKind::Delete) => tracing::info!("Remote ROS 2 bridge left: {}", zenoh_id),

--- a/zenoh-plugin-ros2dds/src/route_publisher.rs
+++ b/zenoh-plugin-ros2dds/src/route_publisher.rs
@@ -198,16 +198,17 @@ impl RoutePublisher {
             priority,
             is_express
         );
-        
+
         let mut publisher_builder = context
             .zsession
             .declare_publisher(zenoh_key_expr.clone())
             .advanced();
         match cache_size {
             Some(size) => {
-                publisher_builder = publisher_builder.cache(CacheConfig::default().max_samples(size));
+                publisher_builder =
+                    publisher_builder.cache(CacheConfig::default().max_samples(size));
             }
-            _ =>(),
+            _ => (),
         }
 
         let publisher: Arc<AdvancedPublisher<'static>> = Arc::new(

--- a/zenoh-plugin-ros2dds/src/route_publisher.rs
+++ b/zenoh-plugin-ros2dds/src/route_publisher.rs
@@ -170,7 +170,7 @@ impl RoutePublisher {
             // In case there are several Writers served by this route, increase the cache size
             history = history.saturating_mul(context.config.transient_local_cache_multiplier);
             tracing::debug!(
-                "Route Publisher ({ros2_name} -> {zenoh_key_expr}): caching TRANSIENT_LOCAL publications via a PublicationCache with history={history} (computed from Reader's QoS: history=({:?},{}), durability_service.max_instances={})",
+                "Route Publisher ({ros2_name} -> {zenoh_key_expr}): caching TRANSIENT_LOCAL publications with history={history} (computed from Reader's QoS: history=({:?},{}), durability_service.max_instances={})",
                 history_qos.kind, history_qos.depth, durability_service_qos.max_instances
             );
             history

--- a/zenoh-plugin-ros2dds/src/route_subscriber.rs
+++ b/zenoh-plugin-ros2dds/src/route_subscriber.rs
@@ -33,8 +33,8 @@ use crate::{
         serialize_entity_guid,
     },
     liveliness_mgt::new_ke_liveliness_sub,
-    qos::Qos,
     qos::History,
+    qos::Qos,
     qos_helpers::is_transient_local,
     ros2_utils::{is_message_for_action, ros2_message_type_to_dds_type},
     routes_mgr::Context,
@@ -185,10 +185,7 @@ impl RouteSubscriber {
                         .detect_late_publishers()
                         .max_samples(depth)
                 }
-                _other => {
-                    HistoryConfig::default()
-                        .detect_late_publishers()
-                }
+                _other => HistoryConfig::default().detect_late_publishers(),
             };
             let sub = self
                 .context

--- a/zenoh-plugin-ros2dds/src/routes_mgr.rs
+++ b/zenoh-plugin-ros2dds/src/routes_mgr.rs
@@ -547,11 +547,11 @@ impl RoutesMgr {
         Ok(())
     }
 
-    pub async fn query_all_historical_publications(&mut self, zenoh_id: &keyexpr) {
-        for route in self.routes_subscribers.values_mut() {
-            route.query_historical_publications(zenoh_id).await;
-        }
-    }
+    // pub async fn query_all_historical_publications(&mut self, zenoh_id: &keyexpr) {
+    //     // for route in self.routes_subscribers.values_mut() {
+    //     //     route.query_historical_publications(zenoh_id).await;
+    //     // }
+    // }
 
     async fn get_or_create_route_publisher(
         &mut self,

--- a/zenoh-plugin-ros2dds/src/routes_mgr.rs
+++ b/zenoh-plugin-ros2dds/src/routes_mgr.rs
@@ -547,12 +547,6 @@ impl RoutesMgr {
         Ok(())
     }
 
-    // pub async fn query_all_historical_publications(&mut self, zenoh_id: &keyexpr) {
-    //     // for route in self.routes_subscribers.values_mut() {
-    //     //     route.query_historical_publications(zenoh_id).await;
-    //     // }
-    // }
-
     async fn get_or_create_route_publisher(
         &mut self,
         ros2_name: String,


### PR DESCRIPTION
Resolves issues #333 and #219.
Following @JEnoch’s suggestion, I replaced the deprecated `PublicationCache` with the `AdvancedPublisher` and AdvancedSubscriber classes, which are already used inside the `rmw_zenoh` project.

In a separate branch `advanced-pubsub-dev`, I am working on configuring the advanced subscriber history to align with the QoS history depth configuration.

Open to any correction.