### PR TITLE
Use the signed key for Eclipse Zenoh repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Choose your platform and download:
 Add Eclipse Zenoh private repository to the sources list:
 
 ```bash
-echo "deb [trusted=yes] https://download.eclipse.org/zenoh/debian-repo/ /" | sudo tee -a /etc/apt/sources.list > /dev/null
+curl -L https://download.eclipse.org/zenoh/debian-repo/zenoh-public-key | sudo gpg --dearmor --yes --output /etc/apt/keyrings/zenoh-public-key.gpg
+echo "deb [signed-by=/etc/apt/keyrings/zenoh-public-key.gpg] https://download.eclipse.org/zenoh/debian-repo/ /" | sudo tee -a /etc/apt/sources.list > /dev/null
 sudo apt update
 ```
 


### PR DESCRIPTION
Now Eclipse Zenoh supports the signed key for the apt repository.
Let's use the same way as the website.
https://zenoh.io/docs/getting-started/installation/