### PR TITLE
fix(routes_mgr): log WARN on DDS QoS mismatch for existing routes

### DIFF
--- a/zenoh-plugin-ros2dds/src/qos_helpers.rs
+++ b/zenoh-plugin-ros2dds/src/qos_helpers.rs
@@ -39,6 +39,46 @@ pub fn is_transient_local(qos: &Qos) -> bool {
         .is_some_and(|durability| durability.kind == DurabilityKind::TRANSIENT_LOCAL)
 }
 
+/// Returns true if `incoming` QoS is compatible with the `existing` route QoS.
+///
+/// Per the DDS specification (§7.1.3):
+/// - Reliability: BEST_EFFORT writer can match a BEST_EFFORT reader;
+///   RELIABLE writer can match any reader; BEST_EFFORT writer cannot
+///   match a RELIABLE reader. In the bridge context both sides must agree.
+/// - Durability: VOLATILE does not deliver historical data; TRANSIENT_LOCAL does.
+///   If the route was created as TRANSIENT_LOCAL but the new entity is VOLATILE
+///   (or vice versa) the DDS endpoint matching will silently fail.
+///
+/// Callers that detect incompatibility should log a WARN so the failure is
+/// observable (D-VGC134-5 silent-failure class — convert silent drop to log
+/// entry). Route teardown/recreation is left to future work.
+pub fn qos_is_compatible(existing: &Qos, incoming: &Qos) -> bool {
+    // Check Reliability compatibility.
+    let existing_reliable = is_reliable(existing);
+    let incoming_reliable = is_reliable(incoming);
+    if existing_reliable != incoming_reliable {
+        return false;
+    }
+    // Check Durability (TRANSIENT_LOCAL vs. VOLATILE) compatibility.
+    let existing_transient = is_transient_local(existing);
+    let incoming_transient = is_transient_local(incoming);
+    if existing_transient != incoming_transient {
+        return false;
+    }
+    true
+}
+
+/// Returns a human-readable summary of Reliability + Durability for log output.
+pub fn qos_summary(qos: &Qos) -> String {
+    let rel = if is_reliable(qos) { "RELIABLE" } else { "BEST_EFFORT" };
+    let dur = if is_transient_local(qos) {
+        "TRANSIENT_LOCAL"
+    } else {
+        "VOLATILE"
+    };
+    format!("{rel}/{dur}")
+}
+
 // Copy and adapt Writer's QoS for creation of a matching Reader
 pub fn adapt_writer_qos_for_reader(qos: &Qos) -> Qos {
     let mut reader_qos = qos.clone();

--- a/zenoh-plugin-ros2dds/src/route_publisher.rs
+++ b/zenoh-plugin-ros2dds/src/route_publisher.rs
@@ -380,6 +380,14 @@ impl RoutePublisher {
     pub fn is_unused(&self) -> bool {
         !self.is_serving_local_node() && !self.is_serving_remote_route()
     }
+
+    /// Returns the QoS this route's DDS Reader was created with.
+    /// Used to detect QoS mismatches when a new entity is discovered for an
+    /// existing route (issue #435 — silent DDS endpoint matching failure).
+    #[inline]
+    pub fn reader_qos(&self) -> &Qos {
+        &self._reader_qos
+    }
 }
 
 pub fn serialize_pub_cache<S>(zpub: &ZPublisher, s: S) -> Result<S::Ok, S::Error>

--- a/zenoh-plugin-ros2dds/src/route_subscriber.rs
+++ b/zenoh-plugin-ros2dds/src/route_subscriber.rs
@@ -76,6 +76,11 @@ pub struct RouteSubscriber {
     // a liveliness token associated to this route, for announcement to other plugins
     #[serde(skip)]
     liveliness_token: Option<LivelinessToken>,
+    // the QoS for the DDS Writer created for this route.
+    // Stored to enable QoS-mismatch detection when a new entity is discovered
+    // for an already-existing route (issue #435 — silent DDS endpoint failure).
+    #[serde(skip)]
+    _writer_qos: Qos,
     // the list of remote routes served by this route ("<zenoh_id>:<zenoh_key_expr>"")
     remote_routes: HashSet<String>,
     // the list of nodes served by this route
@@ -138,6 +143,8 @@ impl RouteSubscriber {
         tracing::debug!(
             "Route Subscriber ({zenoh_key_expr} -> {ros2_name}): create Writer with {writer_qos:?}"
         );
+        // Capture writer_qos before moving it into create_dds_writer
+        let stored_writer_qos = writer_qos.clone();
         let dds_writer = create_dds_writer(
             context.participant,
             topic_name,
@@ -161,6 +168,7 @@ impl RouteSubscriber {
             queries_timeout,
             keyless,
             liveliness_token: None,
+            _writer_qos: stored_writer_qos,
             remote_routes: HashSet::new(),
             local_nodes: HashSet::new(),
         })
@@ -310,6 +318,14 @@ impl RouteSubscriber {
     #[inline]
     pub fn is_unused(&self) -> bool {
         !self.is_serving_local_node() && !self.is_serving_remote_route()
+    }
+
+    /// Returns the QoS this route's DDS Writer was created with.
+    /// Used to detect QoS mismatches when a new entity is discovered for an
+    /// existing route (issue #435 — silent DDS endpoint matching failure).
+    #[inline]
+    pub fn writer_qos(&self) -> &Qos {
+        &self._writer_qos
     }
 }
 

--- a/zenoh-plugin-ros2dds/src/routes_mgr.rs
+++ b/zenoh-plugin-ros2dds/src/routes_mgr.rs
@@ -33,7 +33,7 @@ use crate::{
     config::Config,
     discovered_entities::DiscoveredEntities,
     events::{ROS2AnnouncementEvent, ROS2DiscoveryEvent},
-    qos_helpers::{adapt_reader_qos_for_writer, adapt_writer_qos_for_reader},
+    qos_helpers::{adapt_reader_qos_for_writer, adapt_writer_qos_for_reader, qos_is_compatible, qos_summary},
     ros2_utils::{key_expr_to_ros2_name, ros2_name_to_key_expr},
     ros_discovery::RosDiscoveryInfoMgr,
     route_action_cli::RouteActionCli,
@@ -588,7 +588,22 @@ impl RoutesMgr {
 
                 Ok(entry.insert(route))
             }
-            Entry::Occupied(entry) => Ok(entry.into_mut()),
+            Entry::Occupied(entry) => {
+                // Route already exists: check that the incoming QoS is compatible with
+                // the QoS the route's DDS Reader was created with. A mismatch causes DDS
+                // to silently refuse endpoint matching — no error is surfaced to the caller
+                // (issue #435). Log a WARN so the failure is observable.
+                let route = entry.into_mut();
+                if !qos_is_compatible(route.reader_qos(), &reader_qos) {
+                    tracing::warn!(
+                        "{route} QoS mismatch: route was created with {} but incoming entity \
+                         has {}. DDS endpoint matching may silently fail.",
+                        qos_summary(route.reader_qos()),
+                        qos_summary(&reader_qos),
+                    );
+                }
+                Ok(route)
+            }
         }
     }
 
@@ -625,7 +640,19 @@ impl RoutesMgr {
 
                 Ok(entry.insert(route))
             }
-            Entry::Occupied(entry) => Ok(entry.into_mut()),
+            Entry::Occupied(entry) => {
+                // Route already exists: check QoS compatibility (issue #435 — silent failure).
+                let route = entry.into_mut();
+                if !qos_is_compatible(route.writer_qos(), &writer_qos) {
+                    tracing::warn!(
+                        "{route} QoS mismatch: route was created with {} but incoming entity \
+                         has {}. DDS endpoint matching may silently fail.",
+                        qos_summary(route.writer_qos()),
+                        qos_summary(&writer_qos),
+                    );
+                }
+                Ok(route)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

When a ROS2 node is (re-)discovered for a topic that already has an active bridge route, `get_or_create_route_{publisher,subscriber}` returned the existing route without checking whether the new entity's QoS is compatible with the QoS the route's DDS Reader/Writer was originally created with.

An incompatible Reliability or Durability QoS causes DDS to silently refuse endpoint matching. The bridge holds stale route handles with no error propagated to the Zenoh layer. The only visible symptom is a `Timeout(5s)` warning on the querying side — insufficient to diagnose the root cause.

Closes #435

## Fix

- `qos_helpers`: add `qos_is_compatible(existing, incoming)` checking Reliability × Durability per DDS spec §7.1.3
- `qos_helpers`: add `qos_summary()` for human-readable WARN messages
- `route_publisher`: expose `reader_qos()` (the existing `_reader_qos` field was already stored but unused)
- `route_subscriber`: store `_writer_qos` at route creation; expose `writer_qos()`
- `routes_mgr`: in `get_or_create_route_{publisher,subscriber}` Occupied branch, call `qos_is_compatible()` and emit `tracing::warn!` on mismatch with both QoS summaries

This converts a silent DDS endpoint-matching failure into an observable log entry. Route teardown and recreation on QoS change are left as follow-up work once the detection pattern is confirmed by field testing.

## Existing behavior audit (OPS-RULE-016)

- `routes_mgr.rs:591` — Occupied branch returns `entry.into_mut()` with no QoS comparison
- `route_publisher.rs:100` — `_reader_qos: Qos` field already stored but never exposed or compared
- `route_subscriber.rs` — no QoS field stored at all; added `_writer_qos` in this PR
- `qos_helpers.rs` — `is_reliable()` and `is_transient_local()` existed; `qos_is_compatible()` is new

## Scope classification (OPS-RULE-017)

**(a) Bug fix** — silent failure made observable; no change to route lifecycle behavior.

## Prior art consulted (OPS-RULE-018)

1. Issue [#435](https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/issues/435) — root cause description with multi-host reproduce steps (~90 topics, node cycling)
2. `RouteStatus::_QoSConflict` variant (routes_mgr.rs:62) — already defined but unused; confirms QoS conflict detection was an intended future feature
3. `adapt_writer_qos_for_reader` / `adapt_reader_qos_for_writer` in `qos_helpers.rs` — existing QoS adaptation patterns that this PR extends with a compatibility check

## Test evidence

This plugin requires a live DDS + Zenoh environment to test — unit test coverage for the new `qos_is_compatible` function can be added in a follow-up if the project has a mock DDS harness. The change has been verified to compile cleanly (`cargo check`).

*AI-assisted — authored with Claude, reviewed by Komada.*