### PR TITLE
perf: Scope liveliness subscription by namespace to eliminate N² broa…

### DIFF
--- a/zenoh-plugin-ros2dds/src/lib.rs
+++ b/zenoh-plugin-ros2dds/src/lib.rs
@@ -414,13 +414,21 @@ enum AdminRef {
 
 impl ROS2PluginRuntime {
     async fn run(&mut self) {
-        // Subscribe to all liveliness info from other ROS2 plugins
-        let ke_liveliness_all = keformat!(
-            ke_liveliness_all::formatter(),
-            zenoh_id = "*",
-            remaining = "**"
-        )
-        .unwrap();
+        // Subscribe to liveliness info from other ROS2 plugins.
+        // If a namespace is configured, only subscribe to announcements matching this namespace
+        // to avoid receiving (and creating routes for) announcements from other namespaces.
+        let ke_liveliness_all = if self.config.namespace != "/" {
+            let ns_prefix = &self.config.namespace[1..]; // strip leading '/'
+            OwnedKeyExpr::try_from(format!("@/*/@ros2_lv/*/{}§$*/**", ns_prefix))
+                .expect("Failed to build namespace-scoped liveliness key expression")
+        } else {
+            keformat!(
+                ke_liveliness_all::formatter(),
+                zenoh_id = "*",
+                remaining = "**"
+            )
+            .unwrap()
+        };
         let liveliness_subscriber = self
             .zsession
             .liveliness()


### PR DESCRIPTION

  ## Summary

  - When multiple bridges with different namespaces connect to the same router,
    each bridge subscribes to all liveliness tokens (`@/*/@ros2_lv/**`), causing
    O(N²) control plane overhead as the router forwards every token to every client.
  - Scope the liveliness subscription by namespace: bridges with a configured
    namespace (e.g., `/bot1`) now subscribe only to `@/*/@ros2_lv/*/bot1§$*/**`,
    leveraging the router's per-subscription interest matching to filter at the source.
  - Bridges with default namespace "/" retain the original wildcard subscription
    for backward compatibility.

  ## Test plan

  - [x] Deploy 2+ bridges with different namespaces connected to the same router
  - [x] Verify each bridge only receives liveliness tokens for its own namespace
  - [x] Verify bridge with default namespace "/" still receives all tokens
  - [x] Monitor router control plane traffic to confirm reduced forwarding
