### PR TITLE
fix(#702, #703): key local_nodes by (participant_gid, node_fullname); release CString memory

### DIFF
--- a/zenoh-plugin-ros2dds/src/dds_utils.rs
+++ b/zenoh-plugin-ros2dds/src/dds_utils.rs
@@ -137,7 +137,7 @@ pub unsafe fn create_topic(
     let cton = CString::new(topic_name.to_owned()).unwrap().into_raw();
     let ctyn = CString::new(type_name.to_owned()).unwrap().into_raw();
 
-    match type_info {
+    let topic = match type_info {
         None => cdds_create_blob_topic(dp, cton, ctyn, keyless),
         Some(type_info) => {
             let mut descriptor: *mut dds_topic_descriptor_t = std::ptr::null_mut();
@@ -157,7 +157,13 @@ pub unsafe fn create_topic(
             }
             topic
         }
-    }
+    };
+
+    // Reclaim the CStrings: cyclonedds copies them internally, so it is safe to free now.
+    drop(CString::from_raw(cton));
+    drop(CString::from_raw(ctyn));
+
+    topic
 }
 
 pub fn create_dds_writer(
@@ -175,6 +181,8 @@ pub fn create_dds_writer(
         let qos_native = qos.to_qos_native();
         let writer: i32 = dds_create_writer(dp, t, qos_native, std::ptr::null_mut());
         Qos::delete_qos_native(qos_native);
+        drop(CString::from_raw(cton));
+        drop(CString::from_raw(ctyn));
         if writer >= 0 {
             Ok(writer)
         } else {

--- a/zenoh-plugin-ros2dds/src/dds_utils.rs
+++ b/zenoh-plugin-ros2dds/src/dds_utils.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use std::{
+    collections::{BTreeSet, HashSet},
     ffi::{CStr, CString},
     mem::MaybeUninit,
     sync::{atomic::AtomicI32, Arc},
@@ -22,7 +23,7 @@ use cyclors::{
     qos::{History, HistoryKind, Qos},
     *,
 };
-use serde::Serializer;
+use serde::{ser::SerializeSeq, Serializer};
 use tokio::task;
 
 use crate::{
@@ -30,6 +31,23 @@ use crate::{
     gid::Gid,
     vec_into_raw_parts,
 };
+
+/// Serialize a `HashSet<(Gid, String)>` as a deduplicated array of the node fullnames,
+/// dropping the participant GID. Keeps the admin-space JSON format unchanged after #702 fix.
+pub fn serialize_local_nodes<S>(
+    set: &HashSet<(Gid, String)>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let dedup: BTreeSet<&str> = set.iter().map(|(_, name)| name.as_str()).collect();
+    let mut seq = serializer.serialize_seq(Some(dedup.len()))?;
+    for name in &dedup {
+        seq.serialize_element(name)?;
+    }
+    seq.end()
+}
 
 // An atomic dds_entity_t (=i32), for safe concurrent creation/deletion of DDS entities
 pub type AtomicDDSEntity = AtomicI32;

--- a/zenoh-plugin-ros2dds/src/dds_utils.rs
+++ b/zenoh-plugin-ros2dds/src/dds_utils.rs
@@ -12,10 +12,10 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use std::{
-    collections::{BTreeSet, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     ffi::{CStr, CString},
     mem::MaybeUninit,
-    sync::{atomic::AtomicI32, Arc},
+    sync::{atomic::AtomicI32, Arc, Mutex, OnceLock},
     time::Duration,
 };
 
@@ -53,6 +53,49 @@ where
 pub type AtomicDDSEntity = AtomicI32;
 
 pub const DDS_ENTITY_NULL: dds_entity_t = 0;
+
+type ListenerArgDropper = unsafe fn(usize);
+
+struct DdsEndpointResources {
+    topic: dds_entity_t,
+    listener_arg: Option<(usize, ListenerArgDropper)>,
+}
+
+fn endpoint_resources() -> &'static Mutex<HashMap<dds_entity_t, DdsEndpointResources>> {
+    static RESOURCES: OnceLock<Mutex<HashMap<dds_entity_t, DdsEndpointResources>>> =
+        OnceLock::new();
+    RESOURCES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn register_dds_endpoint(
+    endpoint: dds_entity_t,
+    topic: dds_entity_t,
+    listener_arg: Option<(usize, ListenerArgDropper)>,
+) {
+    let old = endpoint_resources()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(
+            endpoint,
+            DdsEndpointResources {
+                topic,
+                listener_arg,
+            },
+        );
+    if let Some(old) = old {
+        tracing::error!(
+            "DDS endpoint handle {endpoint} was reused before its resources were released"
+        );
+        // A live endpoint may still reference this callback. Preserve it rather
+        // than risking a use-after-free in this impossible-with-valid-handles
+        // fallback path.
+        let _ = old;
+    }
+}
+
+unsafe fn drop_listener_arg<F>(arg: usize) {
+    drop(Box::from_raw(arg as *mut F));
+}
 pub const CDR_HEADER_LE: [u8; 4] = [0, 1, 0, 0];
 pub const CDR_HEADER_BE: [u8; 4] = [0, 0, 0, 0];
 
@@ -94,6 +137,35 @@ pub fn delete_dds_entity(entity: dds_entity_t) -> Result<(), String> {
             e => Err(format!("Error deleting DDS entity - retcode={e}")),
         }
     }
+}
+
+/// Delete a Reader/Writer created by [`create_dds_reader`] or
+/// [`create_dds_writer`] and release the Topic and listener callback owned by
+/// that endpoint.
+pub fn delete_dds_endpoint(entity: dds_entity_t) -> Result<(), String> {
+    let resources = endpoint_resources()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(&entity);
+
+    let Some(resources) = resources else {
+        tracing::warn!("DDS endpoint {entity} has no registered resources");
+        return delete_dds_entity(entity);
+    };
+
+    if let Err(e) = delete_dds_entity(entity) {
+        endpoint_resources()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(entity, resources);
+        return Err(e);
+    }
+
+    let topic_result = delete_dds_entity(resources.topic);
+    if let Some((arg, dropper)) = resources.listener_arg {
+        unsafe { dropper(arg) };
+    }
+    topic_result.map_err(|e| format!("Error deleting Topic for DDS endpoint {entity}: {e}"))
 }
 
 pub fn get_guid(entity: &dds_entity_t) -> Result<Gid, String> {
@@ -196,14 +268,30 @@ pub fn create_dds_writer(
 
     unsafe {
         let t = cdds_create_blob_topic(dp, cton, ctyn, keyless);
+        if t <= 0 {
+            drop(CString::from_raw(cton));
+            drop(CString::from_raw(ctyn));
+            return Err(format!(
+                "Error creating DDS Topic: {}",
+                if t < 0 {
+                    CStr::from_ptr(dds_strretcode(-t))
+                        .to_str()
+                        .unwrap_or("unrecoverable DDS retcode")
+                } else {
+                    "null DDS entity"
+                }
+            ));
+        }
         let qos_native = qos.to_qos_native();
         let writer: i32 = dds_create_writer(dp, t, qos_native, std::ptr::null_mut());
         Qos::delete_qos_native(qos_native);
         drop(CString::from_raw(cton));
         drop(CString::from_raw(ctyn));
-        if writer >= 0 {
+        if writer > 0 {
+            register_dds_endpoint(writer, t, None);
             Ok(writer)
         } else {
+            let _ = delete_dds_entity(t);
             Err(format!(
                 "Error creating DDS Writer: {}",
                 CStr::from_ptr(dds_strretcode(-writer))
@@ -308,17 +396,31 @@ where
 {
     unsafe {
         let t = create_topic(dp, &topic_name, &type_name, type_info, keyless);
+        if t <= 0 {
+            return Err(format!(
+                "Error creating DDS Topic: {}",
+                if t < 0 {
+                    CStr::from_ptr(dds_strretcode(-t))
+                        .to_str()
+                        .unwrap_or("unrecoverable DDS retcode")
+                } else {
+                    "null DDS entity"
+                }
+            ));
+        }
         match read_period {
             None => {
                 // Use a Listener to route data as soon as it arrives
-                let arg = Box::new(callback);
-                let sub_listener =
-                    dds_create_listener(Box::into_raw(arg) as *mut std::os::raw::c_void);
+                let arg = Box::into_raw(Box::new(callback));
+                let sub_listener = dds_create_listener(arg as *mut std::os::raw::c_void);
                 dds_lset_data_available(sub_listener, Some(listener_to_callback::<F>));
                 let qos_native = qos.to_qos_native();
                 let reader = dds_create_reader(dp, t, qos_native, sub_listener);
                 Qos::delete_qos_native(qos_native);
-                if reader >= 0 {
+                // CycloneDDS copies the listener into the Reader.
+                dds_delete_listener(sub_listener);
+                if reader > 0 {
+                    register_dds_endpoint(reader, t, Some((arg as usize, drop_listener_arg::<F>)));
                     let res = dds_reader_wait_for_historical_data(reader, qos::DDS_100MS_DURATION);
                     if res < 0 {
                         tracing::error!(
@@ -330,6 +432,8 @@ where
                     }
                     Ok(reader)
                 } else {
+                    drop(Box::from_raw(arg));
+                    let _ = delete_dds_entity(t);
                     Err(format!(
                         "Error creating DDS Reader: {}",
                         CStr::from_ptr(dds_strretcode(-reader))
@@ -346,6 +450,21 @@ where
                 });
                 let qos_native = qos.to_qos_native();
                 let reader = dds_create_reader(dp, t, qos_native, std::ptr::null());
+                Qos::delete_qos_native(qos_native);
+                if reader <= 0 {
+                    let _ = delete_dds_entity(t);
+                    return Err(format!(
+                        "Error creating DDS Reader: {}",
+                        if reader < 0 {
+                            CStr::from_ptr(dds_strretcode(-reader))
+                                .to_str()
+                                .unwrap_or("unrecoverable DDS retcode")
+                        } else {
+                            "null DDS entity"
+                        }
+                    ));
+                }
+                register_dds_endpoint(reader, t, None);
                 task::spawn(async move {
                     // loop while reader's instance handle remain the same
                     // (if reader was deleted, its dds_entity_t value might have been

--- a/zenoh-plugin-ros2dds/src/discovered_entities.rs
+++ b/zenoh-plugin-ros2dds/src/discovered_entities.rs
@@ -349,7 +349,7 @@ impl DiscoveredEntities {
                     );
                     events.push(e)
                 };
-            } else {
+            } else if !node.undiscovered_reader.contains(rgid) {
                 tracing::debug!(
                     "ROS Node {ros_node_info} declares a not yet discovered DDS Reader: {rgid}"
                 );
@@ -370,7 +370,7 @@ impl DiscoveredEntities {
                     );
                     events.push(e)
                 };
-            } else {
+            } else if !node.undiscovered_writer.contains(wgid) {
                 tracing::debug!(
                     "ROS Node {ros_node_info} declares a not yet discovered DDS Writer: {wgid}"
                 );

--- a/zenoh-plugin-ros2dds/src/events.rs
+++ b/zenoh-plugin-ros2dds/src/events.rs
@@ -17,41 +17,42 @@ use std::fmt::Display;
 use cyclors::qos::Qos;
 use zenoh::key_expr::OwnedKeyExpr;
 
-use crate::node_info::*;
+use crate::{gid::Gid, node_info::*};
 
-/// A (local) discovery event of a ROS2 interface
+/// A (local) discovery event of a ROS2 interface.
+/// First Gid is the participant GID owning the node — used to disambiguate same-named nodes across restarts (#702).
 #[derive(Debug)]
 pub enum ROS2DiscoveryEvent {
-    DiscoveredMsgPub(String, MsgPub),
-    UndiscoveredMsgPub(String, MsgPub),
-    DiscoveredMsgSub(String, MsgSub),
-    UndiscoveredMsgSub(String, MsgSub),
-    DiscoveredServiceSrv(String, ServiceSrv),
-    UndiscoveredServiceSrv(String, ServiceSrv),
-    DiscoveredServiceCli(String, ServiceCli),
-    UndiscoveredServiceCli(String, ServiceCli),
-    DiscoveredActionSrv(String, ActionSrv),
-    UndiscoveredActionSrv(String, ActionSrv),
-    DiscoveredActionCli(String, ActionCli),
-    UndiscoveredActionCli(String, ActionCli),
+    DiscoveredMsgPub(Gid, String, MsgPub),
+    UndiscoveredMsgPub(Gid, String, MsgPub),
+    DiscoveredMsgSub(Gid, String, MsgSub),
+    UndiscoveredMsgSub(Gid, String, MsgSub),
+    DiscoveredServiceSrv(Gid, String, ServiceSrv),
+    UndiscoveredServiceSrv(Gid, String, ServiceSrv),
+    DiscoveredServiceCli(Gid, String, ServiceCli),
+    UndiscoveredServiceCli(Gid, String, ServiceCli),
+    DiscoveredActionSrv(Gid, String, ActionSrv),
+    UndiscoveredActionSrv(Gid, String, ActionSrv),
+    DiscoveredActionCli(Gid, String, ActionCli),
+    UndiscoveredActionCli(Gid, String, ActionCli),
 }
 
 impl std::fmt::Display for ROS2DiscoveryEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use ROS2DiscoveryEvent::*;
         match self {
-            DiscoveredMsgPub(node, iface) => write!(f, "Node {node} declares {iface}"),
-            DiscoveredMsgSub(node, iface) => write!(f, "Node {node} declares {iface}"),
-            DiscoveredServiceSrv(node, iface) => write!(f, "Node {node} declares {iface}"),
-            DiscoveredServiceCli(node, iface) => write!(f, "Node {node} declares {iface}"),
-            DiscoveredActionSrv(node, iface) => write!(f, "Node {node} declares {iface}"),
-            DiscoveredActionCli(node, iface) => write!(f, "Node {node} declares {iface}"),
-            UndiscoveredMsgPub(node, iface) => write!(f, "Node {node} undeclares {iface}"),
-            UndiscoveredMsgSub(node, iface) => write!(f, "Node {node} undeclares {iface}"),
-            UndiscoveredServiceSrv(node, iface) => write!(f, "Node {node} undeclares {iface}"),
-            UndiscoveredServiceCli(node, iface) => write!(f, "Node {node} undeclares {iface}"),
-            UndiscoveredActionSrv(node, iface) => write!(f, "Node {node} undeclares {iface}"),
-            UndiscoveredActionCli(node, iface) => write!(f, "Node {node} undeclares {iface}"),
+            DiscoveredMsgPub(_, node, iface) => write!(f, "Node {node} declares {iface}"),
+            DiscoveredMsgSub(_, node, iface) => write!(f, "Node {node} declares {iface}"),
+            DiscoveredServiceSrv(_, node, iface) => write!(f, "Node {node} declares {iface}"),
+            DiscoveredServiceCli(_, node, iface) => write!(f, "Node {node} declares {iface}"),
+            DiscoveredActionSrv(_, node, iface) => write!(f, "Node {node} declares {iface}"),
+            DiscoveredActionCli(_, node, iface) => write!(f, "Node {node} declares {iface}"),
+            UndiscoveredMsgPub(_, node, iface) => write!(f, "Node {node} undeclares {iface}"),
+            UndiscoveredMsgSub(_, node, iface) => write!(f, "Node {node} undeclares {iface}"),
+            UndiscoveredServiceSrv(_, node, iface) => write!(f, "Node {node} undeclares {iface}"),
+            UndiscoveredServiceCli(_, node, iface) => write!(f, "Node {node} undeclares {iface}"),
+            UndiscoveredActionSrv(_, node, iface) => write!(f, "Node {node} undeclares {iface}"),
+            UndiscoveredActionCli(_, node, iface) => write!(f, "Node {node} undeclares {iface}"),
         }
     }
 }

--- a/zenoh-plugin-ros2dds/src/lib.rs
+++ b/zenoh-plugin-ros2dds/src/lib.rs
@@ -666,22 +666,22 @@ impl ROS2PluginRuntime {
         if let Some(allowance) = &self.config.allowance {
             use ROS2DiscoveryEvent::*;
             match evt {
-                DiscoveredMsgPub(_, iface) | UndiscoveredMsgPub(_, iface) => {
+                DiscoveredMsgPub(_, _, iface) | UndiscoveredMsgPub(_, _, iface) => {
                     allowance.is_publisher_allowed(&iface.name)
                 }
-                DiscoveredMsgSub(_, iface) | UndiscoveredMsgSub(_, iface) => {
+                DiscoveredMsgSub(_, _, iface) | UndiscoveredMsgSub(_, _, iface) => {
                     allowance.is_subscriber_allowed(&iface.name)
                 }
-                DiscoveredServiceSrv(_, iface) | UndiscoveredServiceSrv(_, iface) => {
+                DiscoveredServiceSrv(_, _, iface) | UndiscoveredServiceSrv(_, _, iface) => {
                     allowance.is_service_srv_allowed(&iface.name)
                 }
-                DiscoveredServiceCli(_, iface) | UndiscoveredServiceCli(_, iface) => {
+                DiscoveredServiceCli(_, _, iface) | UndiscoveredServiceCli(_, _, iface) => {
                     allowance.is_service_cli_allowed(&iface.name)
                 }
-                DiscoveredActionSrv(_, iface) | UndiscoveredActionSrv(_, iface) => {
+                DiscoveredActionSrv(_, _, iface) | UndiscoveredActionSrv(_, _, iface) => {
                     allowance.is_action_srv_allowed(&iface.name)
                 }
-                DiscoveredActionCli(_, iface) | UndiscoveredActionCli(_, iface) => {
+                DiscoveredActionCli(_, _, iface) | UndiscoveredActionCli(_, _, iface) => {
                     allowance.is_action_cli_allowed(&iface.name)
                 }
             }

--- a/zenoh-plugin-ros2dds/src/node_info.rs
+++ b/zenoh-plugin-ros2dds/src/node_info.rs
@@ -362,6 +362,9 @@ pub struct NodeInfo {
     // The node unique id is: <participant_gid>/<namespace>/<name>
     #[serde(skip)]
     pub id: String,
+    // Participant GID that owns this node. Used to disambiguate same-named nodes across restarts (#702).
+    #[serde(skip)]
+    pub participant: Gid,
     #[serde(skip)]
     fullname: Range<usize>,
     #[serde(skip)]
@@ -447,6 +450,7 @@ impl NodeInfo {
 
         Ok(NodeInfo {
             id,
+            participant,
             fullname,
             namespace,
             name,
@@ -642,7 +646,7 @@ impl NodeInfo {
             Entry::Vacant(e) => match MsgPub::create(name.into(), typ, *writer) {
                 Ok(t) => {
                     e.insert(t.clone());
-                    Some(DiscoveredMsgPub(node_fullname, t))
+                    Some(DiscoveredMsgPub(self.participant, node_fullname, t))
                 }
                 Err(e) => {
                     tracing::error!(
@@ -661,7 +665,7 @@ impl NodeInfo {
                     );
                 } else if v.writers.insert(*writer) && v.writers.len() == 1 {
                     // Send DiscoveredMsgPub event only for the 1st discovered Writer
-                    result = Some(DiscoveredMsgPub(node_fullname, v.clone()));
+                    result = Some(DiscoveredMsgPub(self.participant, node_fullname, v.clone()));
                 }
                 result
             }
@@ -681,7 +685,7 @@ impl NodeInfo {
             Entry::Vacant(e) => match MsgSub::create(name.into(), typ, *reader) {
                 Ok(t) => {
                     e.insert(t.clone());
-                    Some(DiscoveredMsgSub(node_fullname, t))
+                    Some(DiscoveredMsgSub(self.participant, node_fullname, t))
                 }
                 Err(e) => {
                     tracing::error!(
@@ -700,7 +704,7 @@ impl NodeInfo {
                     );
                 } else if v.readers.insert(*reader) && v.readers.len() == 1 {
                     // Send DiscoveredMsgSub event only for the 1st discovered Reader
-                    result = Some(DiscoveredMsgSub(node_fullname, v.clone()));
+                    result = Some(DiscoveredMsgSub(self.participant, node_fullname, v.clone()));
                 }
                 result
             }
@@ -738,7 +742,7 @@ impl NodeInfo {
                     );
                     v.typ = typ;
                     if v.is_complete() {
-                        result = Some(DiscoveredServiceSrv(node_fullname.clone(), v.clone()))
+                        result = Some(DiscoveredServiceSrv(self.participant, node_fullname.clone(), v.clone()))
                     };
                 }
                 if v.entities.req_reader != *reader {
@@ -750,7 +754,7 @@ impl NodeInfo {
                     }
                     v.entities.req_reader = *reader;
                     if v.is_complete() {
-                        result = Some(DiscoveredServiceSrv(node_fullname, v.clone()))
+                        result = Some(DiscoveredServiceSrv(self.participant, node_fullname, v.clone()))
                     };
                 }
                 result
@@ -789,7 +793,7 @@ impl NodeInfo {
                     );
                     v.typ = typ;
                     if v.is_complete() {
-                        result = Some(DiscoveredServiceSrv(node_fullname.clone(), v.clone()))
+                        result = Some(DiscoveredServiceSrv(self.participant, node_fullname.clone(), v.clone()))
                     };
                 }
                 if v.entities.rep_writer != *writer {
@@ -801,7 +805,7 @@ impl NodeInfo {
                     }
                     v.entities.rep_writer = *writer;
                     if v.is_complete() {
-                        result = Some(DiscoveredServiceSrv(node_fullname, v.clone()))
+                        result = Some(DiscoveredServiceSrv(self.participant, node_fullname, v.clone()))
                     };
                 }
                 result
@@ -840,7 +844,7 @@ impl NodeInfo {
                     );
                     v.typ = typ;
                     if v.is_complete() {
-                        result = Some(DiscoveredServiceCli(node_fullname.clone(), v.clone()))
+                        result = Some(DiscoveredServiceCli(self.participant, node_fullname.clone(), v.clone()))
                     };
                 }
                 if v.entities.rep_reader != *reader {
@@ -852,7 +856,7 @@ impl NodeInfo {
                     }
                     v.entities.rep_reader = *reader;
                     if v.is_complete() {
-                        result = Some(DiscoveredServiceCli(node_fullname, v.clone()))
+                        result = Some(DiscoveredServiceCli(self.participant, node_fullname, v.clone()))
                     };
                 }
                 result
@@ -891,7 +895,7 @@ impl NodeInfo {
                     );
                     v.typ = typ;
                     if v.is_complete() {
-                        result = Some(DiscoveredServiceCli(node_fullname.clone(), v.clone()))
+                        result = Some(DiscoveredServiceCli(self.participant, node_fullname.clone(), v.clone()))
                     };
                 }
                 if v.entities.req_writer != *writer {
@@ -903,7 +907,7 @@ impl NodeInfo {
                     }
                     v.entities.req_writer = *writer;
                     if v.is_complete() {
-                        result = Some(DiscoveredServiceCli(node_fullname, v.clone()))
+                        result = Some(DiscoveredServiceCli(self.participant, node_fullname, v.clone()))
                     };
                 }
                 result
@@ -944,7 +948,7 @@ impl NodeInfo {
                     }
                     v.typ = typ;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionSrv(node_fullname.clone(), v.clone()))
+                        result = Some(DiscoveredActionSrv(self.participant, node_fullname.clone(), v.clone()))
                     };
                 }
                 if v.entities.send_goal.req_reader != *reader {
@@ -956,7 +960,7 @@ impl NodeInfo {
                     }
                     v.entities.send_goal.req_reader = *reader;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionSrv(node_fullname, v.clone()))
+                        result = Some(DiscoveredActionSrv(self.participant, node_fullname, v.clone()))
                     };
                 }
                 result
@@ -997,7 +1001,7 @@ impl NodeInfo {
                     }
                     v.typ = typ;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionSrv(node_fullname.clone(), v.clone()))
+                        result = Some(DiscoveredActionSrv(self.participant, node_fullname.clone(), v.clone()))
                     };
                 }
                 if v.entities.send_goal.rep_writer != *writer {
@@ -1009,7 +1013,7 @@ impl NodeInfo {
                     }
                     v.entities.send_goal.rep_writer = *writer;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionSrv(node_fullname, v.clone()))
+                        result = Some(DiscoveredActionSrv(self.participant, node_fullname, v.clone()))
                     };
                 }
                 result
@@ -1052,7 +1056,7 @@ impl NodeInfo {
                     }
                     v.entities.cancel_goal.req_reader = *reader;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionSrv(node_fullname, v.clone()))
+                        result = Some(DiscoveredActionSrv(self.participant, node_fullname, v.clone()))
                     };
                 }
                 result
@@ -1095,7 +1099,7 @@ impl NodeInfo {
                     }
                     v.entities.cancel_goal.rep_writer = *writer;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionSrv(node_fullname, v.clone()))
+                        result = Some(DiscoveredActionSrv(self.participant, node_fullname, v.clone()))
                     };
                 }
                 result
@@ -1136,7 +1140,7 @@ impl NodeInfo {
                     }
                     v.typ = typ;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionSrv(node_fullname.clone(), v.clone()))
+                        result = Some(DiscoveredActionSrv(self.participant, node_fullname.clone(), v.clone()))
                     };
                 }
                 if v.entities.get_result.req_reader != *reader {
@@ -1148,7 +1152,7 @@ impl NodeInfo {
                     }
                     v.entities.get_result.req_reader = *reader;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionSrv(node_fullname, v.clone()))
+                        result = Some(DiscoveredActionSrv(self.participant, node_fullname, v.clone()))
                     };
                 }
                 result
@@ -1189,7 +1193,7 @@ impl NodeInfo {
                     }
                     v.typ = typ;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionSrv(node_fullname.clone(), v.clone()))
+                        result = Some(DiscoveredActionSrv(self.participant, node_fullname.clone(), v.clone()))
                     };
                 }
                 if v.entities.get_result.rep_writer != *writer {
@@ -1201,7 +1205,7 @@ impl NodeInfo {
                     }
                     v.entities.get_result.rep_writer = *writer;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionSrv(node_fullname, v.clone()))
+                        result = Some(DiscoveredActionSrv(self.participant, node_fullname, v.clone()))
                     };
                 }
                 result
@@ -1244,7 +1248,7 @@ impl NodeInfo {
                     }
                     v.entities.status_writer = *writer;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionSrv(node_fullname, v.clone()))
+                        result = Some(DiscoveredActionSrv(self.participant, node_fullname, v.clone()))
                     };
                 }
                 result
@@ -1285,7 +1289,7 @@ impl NodeInfo {
                     }
                     v.typ = typ;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionSrv(node_fullname.clone(), v.clone()))
+                        result = Some(DiscoveredActionSrv(self.participant, node_fullname.clone(), v.clone()))
                     };
                 }
                 if v.entities.feedback_writer != *writer {
@@ -1297,7 +1301,7 @@ impl NodeInfo {
                     }
                     v.entities.feedback_writer = *writer;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionSrv(node_fullname, v.clone()))
+                        result = Some(DiscoveredActionSrv(self.participant, node_fullname, v.clone()))
                     };
                 }
                 result
@@ -1338,7 +1342,7 @@ impl NodeInfo {
                     }
                     v.typ = typ;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionCli(node_fullname.clone(), v.clone()))
+                        result = Some(DiscoveredActionCli(self.participant, node_fullname.clone(), v.clone()))
                     };
                 }
                 if v.entities.send_goal.rep_reader != *reader {
@@ -1350,7 +1354,7 @@ impl NodeInfo {
                     }
                     v.entities.send_goal.rep_reader = *reader;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionCli(node_fullname, v.clone()))
+                        result = Some(DiscoveredActionCli(self.participant, node_fullname, v.clone()))
                     };
                 }
                 result
@@ -1391,7 +1395,7 @@ impl NodeInfo {
                     }
                     v.typ = typ;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionCli(node_fullname.clone(), v.clone()))
+                        result = Some(DiscoveredActionCli(self.participant, node_fullname.clone(), v.clone()))
                     };
                 }
                 if v.entities.send_goal.req_writer != *writer {
@@ -1403,7 +1407,7 @@ impl NodeInfo {
                     }
                     v.entities.send_goal.req_writer = *writer;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionCli(node_fullname, v.clone()))
+                        result = Some(DiscoveredActionCli(self.participant, node_fullname, v.clone()))
                     };
                 }
                 result
@@ -1446,7 +1450,7 @@ impl NodeInfo {
                     }
                     v.entities.cancel_goal.rep_reader = *reader;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionCli(node_fullname, v.clone()))
+                        result = Some(DiscoveredActionCli(self.participant, node_fullname, v.clone()))
                     };
                 }
                 result
@@ -1489,7 +1493,7 @@ impl NodeInfo {
                     }
                     v.entities.cancel_goal.req_writer = *writer;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionCli(node_fullname, v.clone()))
+                        result = Some(DiscoveredActionCli(self.participant, node_fullname, v.clone()))
                     };
                 }
                 result
@@ -1530,7 +1534,7 @@ impl NodeInfo {
                     }
                     v.typ = typ;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionCli(node_fullname.clone(), v.clone()))
+                        result = Some(DiscoveredActionCli(self.participant, node_fullname.clone(), v.clone()))
                     };
                 }
                 if v.entities.get_result.rep_reader != *reader {
@@ -1542,7 +1546,7 @@ impl NodeInfo {
                     }
                     v.entities.get_result.rep_reader = *reader;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionCli(node_fullname, v.clone()))
+                        result = Some(DiscoveredActionCli(self.participant, node_fullname, v.clone()))
                     };
                 }
                 result
@@ -1583,7 +1587,7 @@ impl NodeInfo {
                     }
                     v.typ = typ;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionCli(node_fullname.clone(), v.clone()))
+                        result = Some(DiscoveredActionCli(self.participant, node_fullname.clone(), v.clone()))
                     };
                 }
                 if v.entities.get_result.req_writer != *writer {
@@ -1595,7 +1599,7 @@ impl NodeInfo {
                     }
                     v.entities.get_result.req_writer = *writer;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionCli(node_fullname, v.clone()))
+                        result = Some(DiscoveredActionCli(self.participant, node_fullname, v.clone()))
                     };
                 }
                 result
@@ -1638,7 +1642,7 @@ impl NodeInfo {
                     }
                     v.entities.status_reader = *reader;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionCli(node_fullname, v.clone()))
+                        result = Some(DiscoveredActionCli(self.participant, node_fullname, v.clone()))
                     };
                 }
                 result
@@ -1679,7 +1683,7 @@ impl NodeInfo {
                     }
                     v.typ = typ;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionCli(node_fullname.clone(), v.clone()))
+                        result = Some(DiscoveredActionCli(self.participant, node_fullname.clone(), v.clone()))
                     };
                 }
                 if v.entities.feedback_reader != *reader {
@@ -1691,7 +1695,7 @@ impl NodeInfo {
                     }
                     v.entities.feedback_reader = *reader;
                     if v.is_complete() {
-                        result = Some(DiscoveredActionCli(node_fullname, v.clone()))
+                        result = Some(DiscoveredActionCli(self.participant, node_fullname, v.clone()))
                     };
                 }
                 result
@@ -1706,22 +1710,22 @@ impl NodeInfo {
         let mut events = Vec::new();
 
         for (_, v) in self.msg_pub.drain() {
-            events.push(UndiscoveredMsgPub(node_fullname.clone(), v))
+            events.push(UndiscoveredMsgPub(self.participant, node_fullname.clone(), v))
         }
         for (_, v) in self.msg_sub.drain() {
-            events.push(UndiscoveredMsgSub(node_fullname.clone(), v))
+            events.push(UndiscoveredMsgSub(self.participant, node_fullname.clone(), v))
         }
         for (_, v) in self.service_srv.drain() {
-            events.push(UndiscoveredServiceSrv(node_fullname.clone(), v))
+            events.push(UndiscoveredServiceSrv(self.participant, node_fullname.clone(), v))
         }
         for (_, v) in self.service_cli.drain() {
-            events.push(UndiscoveredServiceCli(node_fullname.clone(), v))
+            events.push(UndiscoveredServiceCli(self.participant, node_fullname.clone(), v))
         }
         for (_, v) in self.action_srv.drain() {
-            events.push(UndiscoveredActionSrv(node_fullname.clone(), v))
+            events.push(UndiscoveredActionSrv(self.participant, node_fullname.clone(), v))
         }
         for (_, v) in self.action_cli.drain() {
-            events.push(UndiscoveredActionCli(node_fullname.clone(), v))
+            events.push(UndiscoveredActionCli(self.participant, node_fullname.clone(), v))
         }
         self.undiscovered_reader.resize(0, Gid::NOT_DISCOVERED);
         self.undiscovered_writer.resize(0, Gid::NOT_DISCOVERED);
@@ -1745,8 +1749,7 @@ impl NodeInfo {
             }
         }) {
             // Return undiscovery event for this Subscriber, since all its DDS Writer have been undiscovered
-            return Some(UndiscoveredMsgSub(
-                node_fullname,
+            return Some(UndiscoveredMsgSub(self.participant, node_fullname,
                 self.msg_sub.remove(&name).unwrap(),
             ));
         }
@@ -1755,8 +1758,7 @@ impl NodeInfo {
             .iter()
             .find(|(_, v)| v.entities.req_reader == *reader)
         {
-            return Some(UndiscoveredServiceSrv(
-                node_fullname,
+            return Some(UndiscoveredServiceSrv(self.participant, node_fullname,
                 self.service_srv.remove(&name.clone()).unwrap(),
             ));
         }
@@ -1765,8 +1767,7 @@ impl NodeInfo {
             .iter()
             .find(|(_, v)| v.entities.rep_reader == *reader)
         {
-            return Some(UndiscoveredServiceCli(
-                node_fullname,
+            return Some(UndiscoveredServiceCli(self.participant, node_fullname,
                 self.service_cli.remove(&name.clone()).unwrap(),
             ));
         }
@@ -1775,8 +1776,7 @@ impl NodeInfo {
                 || v.entities.cancel_goal.req_reader == *reader
                 || v.entities.get_result.req_reader == *reader
         }) {
-            return Some(UndiscoveredActionSrv(
-                node_fullname,
+            return Some(UndiscoveredActionSrv(self.participant, node_fullname,
                 self.action_srv.remove(&name.clone()).unwrap(),
             ));
         }
@@ -1787,8 +1787,7 @@ impl NodeInfo {
                 || v.entities.status_reader == *reader
                 || v.entities.feedback_reader == *reader
         }) {
-            return Some(UndiscoveredActionCli(
-                node_fullname,
+            return Some(UndiscoveredActionCli(self.participant, node_fullname,
                 self.action_cli.remove(&name.clone()).unwrap(),
             ));
         }
@@ -1812,8 +1811,7 @@ impl NodeInfo {
             }
         }) {
             // Return undiscovery event for this Publisher, since all its DDS Writer have been undiscovered
-            return Some(UndiscoveredMsgPub(
-                node_fullname,
+            return Some(UndiscoveredMsgPub(self.participant, node_fullname,
                 self.msg_pub.remove(&name).unwrap(),
             ));
         }
@@ -1822,8 +1820,7 @@ impl NodeInfo {
             .iter()
             .find(|(_, v)| v.entities.rep_writer == *writer)
         {
-            return Some(UndiscoveredServiceSrv(
-                node_fullname,
+            return Some(UndiscoveredServiceSrv(self.participant, node_fullname,
                 self.service_srv.remove(&name.clone()).unwrap(),
             ));
         }
@@ -1832,8 +1829,7 @@ impl NodeInfo {
             .iter()
             .find(|(_, v)| v.entities.req_writer == *writer)
         {
-            return Some(UndiscoveredServiceCli(
-                node_fullname,
+            return Some(UndiscoveredServiceCli(self.participant, node_fullname,
                 self.service_cli.remove(&name.clone()).unwrap(),
             ));
         }
@@ -1844,8 +1840,7 @@ impl NodeInfo {
                 || v.entities.status_writer == *writer
                 || v.entities.feedback_writer == *writer
         }) {
-            return Some(UndiscoveredActionSrv(
-                node_fullname,
+            return Some(UndiscoveredActionSrv(self.participant, node_fullname,
                 self.action_srv.remove(&name.clone()).unwrap(),
             ));
         }
@@ -1854,8 +1849,7 @@ impl NodeInfo {
                 || v.entities.cancel_goal.req_writer == *writer
                 || v.entities.get_result.req_writer == *writer
         }) {
-            return Some(UndiscoveredActionCli(
-                node_fullname,
+            return Some(UndiscoveredActionCli(self.participant, node_fullname,
                 self.action_cli.remove(&name.clone()).unwrap(),
             ));
         }

--- a/zenoh-plugin-ros2dds/src/route_action_cli.rs
+++ b/zenoh-plugin-ros2dds/src/route_action_cli.rs
@@ -20,9 +20,9 @@ use zenoh::{
 };
 
 use crate::{
-    liveliness_mgt::new_ke_liveliness_action_cli, ros2_utils::*,
-    route_action_srv::serialize_action_zenoh_key_expr, route_service_cli::RouteServiceCli,
-    route_subscriber::RouteSubscriber, routes_mgr::Context,
+    dds_utils::serialize_local_nodes, gid::Gid, liveliness_mgt::new_ke_liveliness_action_cli,
+    ros2_utils::*, route_action_srv::serialize_action_zenoh_key_expr,
+    route_service_cli::RouteServiceCli, route_subscriber::RouteSubscriber, routes_mgr::Context,
 };
 
 #[derive(Serialize)]
@@ -56,8 +56,9 @@ pub struct RouteActionCli {
     liveliness_token: Option<LivelinessToken>,
     // the list of remote routes served by this route ("<zenoh_id>:<zenoh_key_expr>"")
     remote_routes: HashSet<String>,
-    // the list of nodes served by this route
-    local_nodes: HashSet<String>,
+    // the list of nodes served by this route, keyed by (participant_gid, node_fullname) — #702.
+    #[serde(serialize_with = "serialize_local_nodes")]
+    local_nodes: HashSet<(Gid, String)>,
 }
 
 impl fmt::Display for RouteActionCli {
@@ -246,40 +247,41 @@ impl RouteActionCli {
     }
 
     #[inline]
-    pub async fn add_local_node(&mut self, node: String) {
+    pub async fn add_local_node(&mut self, node_key: (Gid, String)) {
         futures::join!(
-            self.route_send_goal.add_local_node(node.clone()),
-            self.route_cancel_goal.add_local_node(node.clone()),
-            self.route_get_result.add_local_node(node.clone()),
+            self.route_send_goal.add_local_node(node_key.clone()),
+            self.route_cancel_goal.add_local_node(node_key.clone()),
+            self.route_get_result.add_local_node(node_key.clone()),
             self.route_feedback
-                .add_local_node(node.clone(), &QOS_DEFAULT_ACTION_FEEDBACK),
+                .add_local_node(node_key.clone(), &QOS_DEFAULT_ACTION_FEEDBACK),
             self.route_status
-                .add_local_node(node.clone(), &QOS_DEFAULT_ACTION_STATUS),
+                .add_local_node(node_key.clone(), &QOS_DEFAULT_ACTION_STATUS),
         );
 
-        self.local_nodes.insert(node);
-        tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
-        // if 1st local node added, activate the route
-        if self.local_nodes.len() == 1 {
+        if self.local_nodes.insert(node_key) && self.local_nodes.len() == 1 {
+            tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
             if let Err(e) = self.announce_route().await {
                 tracing::error!("{self} activation failed: {e}");
             }
+        } else {
+            tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
         }
     }
 
     #[inline]
-    pub fn remove_local_node(&mut self, node: &str) {
-        self.route_send_goal.remove_local_node(node);
-        self.route_cancel_goal.remove_local_node(node);
-        self.route_get_result.remove_local_node(node);
-        self.route_feedback.remove_local_node(node);
-        self.route_status.remove_local_node(node);
+    pub fn remove_local_node(&mut self, node_key: &(Gid, String)) {
+        self.route_send_goal.remove_local_node(node_key);
+        self.route_cancel_goal.remove_local_node(node_key);
+        self.route_get_result.remove_local_node(node_key);
+        self.route_feedback.remove_local_node(node_key);
+        self.route_status.remove_local_node(node_key);
 
-        self.local_nodes.remove(node);
-        tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
-        // if last local node removed, deactivate the route
-        if self.local_nodes.is_empty() {
-            self.retire_route();
+        if self.local_nodes.remove(node_key) {
+            tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
+            // if last local node removed, deactivate the route
+            if self.local_nodes.is_empty() {
+                self.retire_route();
+            }
         }
     }
 

--- a/zenoh-plugin-ros2dds/src/route_action_srv.rs
+++ b/zenoh-plugin-ros2dds/src/route_action_srv.rs
@@ -20,8 +20,9 @@ use zenoh::{
 };
 
 use crate::{
-    liveliness_mgt::new_ke_liveliness_action_srv, ros2_utils::*, route_publisher::RoutePublisher,
-    route_service_srv::RouteServiceSrv, routes_mgr::Context,
+    dds_utils::serialize_local_nodes, gid::Gid, liveliness_mgt::new_ke_liveliness_action_srv,
+    ros2_utils::*, route_publisher::RoutePublisher, route_service_srv::RouteServiceSrv,
+    routes_mgr::Context,
 };
 
 #[derive(Serialize)]
@@ -55,8 +56,9 @@ pub struct RouteActionSrv {
     liveliness_token: Option<LivelinessToken>,
     // the list of remote routes served by this route ("<zenoh_id>:<zenoh_key_expr>"")
     remote_routes: HashSet<String>,
-    // the list of nodes served by this route
-    local_nodes: HashSet<String>,
+    // the list of nodes served by this route, keyed by (participant_gid, node_fullname) — #702.
+    #[serde(serialize_with = "serialize_local_nodes")]
+    local_nodes: HashSet<(Gid, String)>,
 }
 
 impl fmt::Display for RouteActionSrv {
@@ -232,40 +234,41 @@ impl RouteActionSrv {
     }
 
     #[inline]
-    pub async fn add_local_node(&mut self, node: String) {
+    pub async fn add_local_node(&mut self, node_key: (Gid, String)) {
         futures::join!(
-            self.route_send_goal.add_local_node(node.clone()),
-            self.route_cancel_goal.add_local_node(node.clone()),
-            self.route_get_result.add_local_node(node.clone()),
+            self.route_send_goal.add_local_node(node_key.clone()),
+            self.route_cancel_goal.add_local_node(node_key.clone()),
+            self.route_get_result.add_local_node(node_key.clone()),
             self.route_feedback
-                .add_local_node(node.clone(), &QOS_DEFAULT_ACTION_FEEDBACK),
+                .add_local_node(node_key.clone(), &QOS_DEFAULT_ACTION_FEEDBACK),
             self.route_status
-                .add_local_node(node.clone(), &QOS_DEFAULT_ACTION_STATUS),
+                .add_local_node(node_key.clone(), &QOS_DEFAULT_ACTION_STATUS),
         );
 
-        self.local_nodes.insert(node);
-        tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
-        // if 1st local node added, activate the route
-        if self.local_nodes.len() == 1 {
+        if self.local_nodes.insert(node_key) && self.local_nodes.len() == 1 {
+            tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
             if let Err(e) = self.announce_route().await {
                 tracing::error!("{self} activation failed: {e}");
             }
+        } else {
+            tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
         }
     }
 
     #[inline]
-    pub fn remove_local_node(&mut self, node: &str) {
-        self.route_send_goal.remove_local_node(node);
-        self.route_cancel_goal.remove_local_node(node);
-        self.route_get_result.remove_local_node(node);
-        self.route_feedback.remove_local_node(node);
-        self.route_status.remove_local_node(node);
+    pub fn remove_local_node(&mut self, node_key: &(Gid, String)) {
+        self.route_send_goal.remove_local_node(node_key);
+        self.route_cancel_goal.remove_local_node(node_key);
+        self.route_get_result.remove_local_node(node_key);
+        self.route_feedback.remove_local_node(node_key);
+        self.route_status.remove_local_node(node_key);
 
-        self.local_nodes.remove(node);
-        tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
-        // if last local node removed, deactivate the route
-        if self.local_nodes.is_empty() {
-            self.retire_route();
+        if self.local_nodes.remove(node_key) {
+            tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
+            // if last local node removed, deactivate the route
+            if self.local_nodes.is_empty() {
+                self.retire_route();
+            }
         }
     }
 

--- a/zenoh-plugin-ros2dds/src/route_publisher.rs
+++ b/zenoh-plugin-ros2dds/src/route_publisher.rs
@@ -38,8 +38,9 @@ use crate::{
     dds_types::{DDSRawSample, TypeInfo},
     dds_utils::{
         create_dds_reader, delete_dds_entity, get_guid, serialize_atomic_entity_guid,
-        AtomicDDSEntity, DDS_ENTITY_NULL,
+        serialize_local_nodes, AtomicDDSEntity, DDS_ENTITY_NULL,
     },
+    gid::Gid,
     liveliness_mgt::new_ke_liveliness_pub,
     qos_helpers::*,
     ros2_utils::{is_message_for_action, ros2_message_type_to_dds_type},
@@ -103,8 +104,10 @@ pub struct RoutePublisher {
     liveliness_token: Option<LivelinessToken>,
     // the list of remote routes served by this route ("<zenoh_id>:<zenoh_key_expr>"")
     remote_routes: HashSet<String>,
-    // the list of nodes served by this route
-    local_nodes: HashSet<String>,
+    // the list of nodes served by this route, keyed by (participant_gid, node_fullname) to
+    // disambiguate same-named nodes across restarts (#702).
+    #[serde(serialize_with = "serialize_local_nodes")]
+    local_nodes: HashSet<(Gid, String)>,
 }
 
 impl Drop for RoutePublisher {
@@ -348,8 +351,12 @@ impl RoutePublisher {
     }
 
     #[inline]
-    pub async fn add_local_node(&mut self, node: String, discovered_writer_qos: &Qos) {
-        if self.local_nodes.insert(node) {
+    pub async fn add_local_node(
+        &mut self,
+        node_key: (Gid, String),
+        discovered_writer_qos: &Qos,
+    ) {
+        if self.local_nodes.insert(node_key) {
             tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
             // if 1st local node added, announce the route
             if self.local_nodes.len() == 1 {
@@ -361,8 +368,8 @@ impl RoutePublisher {
     }
 
     #[inline]
-    pub fn remove_local_node(&mut self, node: &str) {
-        if self.local_nodes.remove(node) {
+    pub fn remove_local_node(&mut self, node_key: &(Gid, String)) {
+        if self.local_nodes.remove(node_key) {
             tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
             // if last local node removed, retire the route
             if self.local_nodes.is_empty() {

--- a/zenoh-plugin-ros2dds/src/route_publisher.rs
+++ b/zenoh-plugin-ros2dds/src/route_publisher.rs
@@ -16,7 +16,10 @@ use std::{
     collections::HashSet,
     fmt,
     ops::Deref,
-    sync::{atomic::Ordering, Arc},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
     time::Duration,
 };
 
@@ -37,7 +40,7 @@ use zenoh_ext::{AdvancedPublisher, AdvancedPublisherBuilderExt, CacheConfig};
 use crate::{
     dds_types::{DDSRawSample, TypeInfo},
     dds_utils::{
-        create_dds_reader, delete_dds_entity, get_guid, serialize_atomic_entity_guid,
+        create_dds_reader, delete_dds_endpoint, get_guid, serialize_atomic_entity_guid,
         serialize_local_nodes, AtomicDDSEntity, DDS_ENTITY_NULL,
     },
     gid::Gid,
@@ -48,6 +51,15 @@ use crate::{
     routes_mgr::Context,
     Config, LOG_PAYLOAD,
 };
+
+const DDS_READER_ACTIVATION_RETRY_DELAYS: [Duration; 6] = [
+    Duration::from_millis(100),
+    Duration::from_millis(250),
+    Duration::from_millis(500),
+    Duration::from_secs(1),
+    Duration::from_secs(2),
+    Duration::from_secs(5),
+];
 
 pub struct ZPublisher {
     publisher: Arc<AdvancedPublisher<'static>>,
@@ -85,6 +97,10 @@ pub struct RoutePublisher {
     // the local DDS Reader created to serve the route (i.e. re-publish to zenoh message coming from DDS)
     #[serde(serialize_with = "serialize_atomic_entity_guid")]
     dds_reader: Arc<AtomicDDSEntity>,
+    // Whether the Zenoh publisher currently has remote subscribers. Kept on
+    // the route so Drop can cancel an in-flight activation task.
+    #[serde(skip)]
+    matching_subscribers: Arc<AtomicBool>,
     // the Zenoh Priority for publications
     #[serde(serialize_with = "serialize_priority")]
     priority: Priority,
@@ -112,6 +128,7 @@ pub struct RoutePublisher {
 
 impl Drop for RoutePublisher {
     fn drop(&mut self) {
+        self.matching_subscribers.store(false, Ordering::Release);
         self.deactivate_dds_reader();
     }
 }
@@ -223,11 +240,15 @@ impl RoutePublisher {
         // activate/deactivate DDS Reader on detection/undetection of matching Subscribers
         // (copy/move all required args for the callback)
         let dds_reader: Arc<AtomicDDSEntity> = Arc::new(DDS_ENTITY_NULL.into());
+        let matching_subscribers = Arc::new(AtomicBool::new(false));
+        let activation_in_progress = Arc::new(AtomicBool::new(false));
 
         publisher
             .matching_listener()
             .callback({
                 let dds_reader = dds_reader.clone();
+                let matching_subscribers = matching_subscribers.clone();
+                let activation_in_progress = activation_in_progress.clone();
                 let ros2_name = ros2_name.clone();
                 let ros2_type = ros2_type.clone();
                 let zenoh_key_expr = zenoh_key_expr.clone();
@@ -241,20 +262,27 @@ impl RoutePublisher {
                 move |status| {
                     tracing::debug!("{route_id} MatchingStatus changed: {status:?}");
                     if status.matching() {
-                        if let Err(e) = activate_dds_reader(
-                            &dds_reader,
-                            &ros2_name,
-                            &ros2_type,
-                            &route_id,
-                            &context,
-                            keyless,
-                            &reader_qos,
-                            &type_info,
-                            &publisher,
-                        ) {
-                            tracing::error!("{route_id}: failed to activate DDS Reader: {e}");
+                        matching_subscribers.store(true, Ordering::Release);
+                        if activation_in_progress
+                            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                            .is_ok()
+                        {
+                            spawn_dds_reader_activation(
+                                dds_reader.clone(),
+                                matching_subscribers.clone(),
+                                activation_in_progress.clone(),
+                                ros2_name.clone(),
+                                ros2_type.clone(),
+                                route_id.clone(),
+                                context.clone(),
+                                keyless,
+                                reader_qos.clone(),
+                                type_info.clone(),
+                                publisher.clone(),
+                            );
                         }
                     } else {
+                        matching_subscribers.store(false, Ordering::Release);
                         deactivate_dds_reader(&dds_reader, &route_id, &context.ros_discovery_mgr)
                     }
                 }
@@ -273,6 +301,7 @@ impl RoutePublisher {
                 cache_size,
             },
             dds_reader,
+            matching_subscribers,
             priority,
             _type_info: type_info.clone(),
             _reader_qos: reader_qos,
@@ -284,14 +313,14 @@ impl RoutePublisher {
     }
 
     fn deactivate_dds_reader(&mut self) {
-        let dds_reader = self.dds_reader.swap(DDS_ENTITY_NULL, Ordering::Relaxed);
+        let dds_reader = self.dds_reader.swap(DDS_ENTITY_NULL, Ordering::AcqRel);
         if dds_reader != DDS_ENTITY_NULL {
             // remove reader's GID from ros_discovery_info message
             match get_guid(&dds_reader) {
                 Ok(gid) => self.context.ros_discovery_mgr.remove_dds_reader(gid),
                 Err(e) => tracing::warn!("{self}: {e}"),
             }
-            if let Err(e) = delete_dds_entity(dds_reader) {
+            if let Err(e) = delete_dds_endpoint(dds_reader) {
                 tracing::warn!("{}: error deleting DDS Reader:  {}", self, e);
             }
         }
@@ -351,11 +380,7 @@ impl RoutePublisher {
     }
 
     #[inline]
-    pub async fn add_local_node(
-        &mut self,
-        node_key: (Gid, String),
-        discovered_writer_qos: &Qos,
-    ) {
+    pub async fn add_local_node(&mut self, node_key: (Gid, String), discovered_writer_qos: &Qos) {
         if self.local_nodes.insert(node_key) {
             tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
             // if 1st local node added, announce the route
@@ -411,6 +436,80 @@ fn get_read_period(config: &Config, ros2_name: &str) -> Option<Duration> {
 }
 
 #[allow(clippy::too_many_arguments)]
+fn spawn_dds_reader_activation(
+    dds_reader: Arc<AtomicDDSEntity>,
+    matching_subscribers: Arc<AtomicBool>,
+    activation_in_progress: Arc<AtomicBool>,
+    ros2_name: String,
+    ros2_type: String,
+    route_id: String,
+    context: Context,
+    keyless: bool,
+    reader_qos: Qos,
+    type_info: Option<Arc<TypeInfo>>,
+    publisher: Arc<AdvancedPublisher<'static>>,
+) {
+    tokio::spawn(async move {
+        let mut failures = 0usize;
+
+        while matching_subscribers.load(Ordering::Acquire)
+            && dds_reader.load(Ordering::Acquire) == DDS_ENTITY_NULL
+        {
+            match activate_dds_reader(
+                &dds_reader,
+                &ros2_name,
+                &ros2_type,
+                &route_id,
+                &context,
+                keyless,
+                &reader_qos,
+                &type_info,
+                &publisher,
+            ) {
+                Ok(()) => {
+                    if !matching_subscribers.load(Ordering::Acquire) {
+                        deactivate_dds_reader(&dds_reader, &route_id, &context.ros_discovery_mgr);
+                    }
+                    break;
+                }
+                Err(e) => {
+                    let delay = DDS_READER_ACTIVATION_RETRY_DELAYS
+                        [failures.min(DDS_READER_ACTIVATION_RETRY_DELAYS.len() - 1)];
+                    failures = failures.saturating_add(1);
+                    tracing::error!(
+                        "{route_id}: failed to activate DDS Reader: {e}; retrying in {delay:?}"
+                    );
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
+
+        activation_in_progress.store(false, Ordering::Release);
+
+        if matching_subscribers.load(Ordering::Acquire)
+            && dds_reader.load(Ordering::Acquire) == DDS_ENTITY_NULL
+            && activation_in_progress
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+        {
+            spawn_dds_reader_activation(
+                dds_reader,
+                matching_subscribers,
+                activation_in_progress,
+                ros2_name,
+                ros2_type,
+                route_id,
+                context,
+                keyless,
+                reader_qos,
+                type_info,
+                publisher,
+            );
+        }
+    });
+}
+
+#[allow(clippy::too_many_arguments)]
 fn activate_dds_reader(
     dds_reader: &Arc<AtomicDDSEntity>,
     ros2_name: &str,
@@ -444,13 +543,22 @@ fn activate_dds_reader(
             }
         },
     )?;
-    let old = dds_reader.deref().swap(reader, Ordering::Relaxed);
-    // add reader's GID in ros_discovery_info message
-    context.ros_discovery_mgr.add_dds_reader(get_guid(&reader)?);
+    let reader_gid = match get_guid(&reader) {
+        Ok(gid) => gid,
+        Err(e) => {
+            let _ = delete_dds_endpoint(reader);
+            return Err(e);
+        }
+    };
+    context.ros_discovery_mgr.add_dds_reader(reader_gid);
+    let old = dds_reader.deref().swap(reader, Ordering::AcqRel);
 
     if old != DDS_ENTITY_NULL {
         tracing::warn!("{route_id}: on activation their was already a DDS Reader - overwrite it");
-        if let Err(e) = delete_dds_entity(old) {
+        if let Ok(gid) = get_guid(&old) {
+            context.ros_discovery_mgr.remove_dds_reader(gid);
+        }
+        if let Err(e) = delete_dds_endpoint(old) {
             tracing::warn!("{route_id}: failed to delete overwritten DDS Reader: {e}");
         }
     }
@@ -464,14 +572,14 @@ fn deactivate_dds_reader(
     ros_discovery_mgr: &Arc<RosDiscoveryInfoMgr>,
 ) {
     tracing::debug!("{route_id}: delete Reader");
-    let reader = dds_reader.swap(DDS_ENTITY_NULL, Ordering::Relaxed);
+    let reader = dds_reader.swap(DDS_ENTITY_NULL, Ordering::AcqRel);
     if reader != DDS_ENTITY_NULL {
         // remove reader's GID from ros_discovery_info message
         match get_guid(&reader) {
             Ok(gid) => ros_discovery_mgr.remove_dds_reader(gid),
             Err(e) => tracing::warn!("{route_id}: {e}"),
         }
-        if let Err(e) = delete_dds_entity(reader) {
+        if let Err(e) = delete_dds_endpoint(reader) {
             tracing::warn!("{route_id}: error deleting DDS Reader:  {e}");
         }
     }

--- a/zenoh-plugin-ros2dds/src/route_service_cli.rs
+++ b/zenoh-plugin-ros2dds/src/route_service_cli.rs
@@ -39,8 +39,10 @@ use crate::{
     dds_types::{DDSRawSample, TypeInfo},
     dds_utils::{
         create_dds_reader, create_dds_writer, dds_write, delete_dds_entity, get_guid,
-        is_cdr_little_endian, serialize_atomic_entity_guid, AtomicDDSEntity, DDS_ENTITY_NULL,
+        is_cdr_little_endian, serialize_atomic_entity_guid, serialize_local_nodes,
+        AtomicDDSEntity, DDS_ENTITY_NULL,
     },
+    gid::Gid,
     liveliness_mgt::new_ke_liveliness_service_cli,
     ros2_utils::{
         is_service_for_action, new_service_id, ros2_service_type_to_reply_dds_type,
@@ -79,8 +81,9 @@ pub struct RouteServiceCli {
     liveliness_token: Option<LivelinessToken>,
     // the list of remote routes served by this route ("<zenoh_id>:<zenoh_key_expr>"")
     remote_routes: HashSet<String>,
-    // the list of nodes served by this route
-    local_nodes: HashSet<String>,
+    // the list of nodes served by this route, keyed by (participant_gid, node_fullname) — #702.
+    #[serde(serialize_with = "serialize_local_nodes")]
+    local_nodes: HashSet<(Gid, String)>,
 }
 
 impl Drop for RouteServiceCli {
@@ -253,24 +256,25 @@ impl RouteServiceCli {
     }
 
     #[inline]
-    pub async fn add_local_node(&mut self, node: String) {
-        self.local_nodes.insert(node);
-        tracing::debug!("{self}: now serving local nodes {:?}", self.local_nodes);
-        // if 1st local node added, announce the route
-        if self.local_nodes.len() == 1 {
+    pub async fn add_local_node(&mut self, node_key: (Gid, String)) {
+        if self.local_nodes.insert(node_key) && self.local_nodes.len() == 1 {
+            tracing::debug!("{self}: now serving local nodes {:?}", self.local_nodes);
             if let Err(e) = self.announce_route().await {
                 tracing::error!("{self}: announcement failed: {e}");
             }
+        } else {
+            tracing::debug!("{self}: now serving local nodes {:?}", self.local_nodes);
         }
     }
 
     #[inline]
-    pub fn remove_local_node(&mut self, node: &str) {
-        self.local_nodes.remove(node);
-        tracing::debug!("{self}: now serving local nodes {:?}", self.local_nodes);
-        // if last local node removed, retire the route
-        if self.local_nodes.is_empty() {
-            self.retire_route();
+    pub fn remove_local_node(&mut self, node_key: &(Gid, String)) {
+        if self.local_nodes.remove(node_key) {
+            tracing::debug!("{self}: now serving local nodes {:?}", self.local_nodes);
+            // if last local node removed, retire the route
+            if self.local_nodes.is_empty() {
+                self.retire_route();
+            }
         }
     }
 

--- a/zenoh-plugin-ros2dds/src/route_service_cli.rs
+++ b/zenoh-plugin-ros2dds/src/route_service_cli.rs
@@ -38,9 +38,9 @@ use zenoh::{
 use crate::{
     dds_types::{DDSRawSample, TypeInfo},
     dds_utils::{
-        create_dds_reader, create_dds_writer, dds_write, delete_dds_entity, get_guid,
-        is_cdr_little_endian, serialize_atomic_entity_guid, serialize_local_nodes,
-        AtomicDDSEntity, DDS_ENTITY_NULL,
+        create_dds_reader, create_dds_writer, dds_write, delete_dds_endpoint, get_guid,
+        is_cdr_little_endian, serialize_atomic_entity_guid, serialize_local_nodes, AtomicDDSEntity,
+        DDS_ENTITY_NULL,
     },
     gid::Gid,
     liveliness_mgt::new_ke_liveliness_service_cli,
@@ -52,6 +52,15 @@ use crate::{
     routes_mgr::Context,
     LOG_PAYLOAD,
 };
+
+const DDS_SERVICE_ACTIVATION_RETRY_DELAYS: [Duration; 6] = [
+    Duration::from_millis(100),
+    Duration::from_millis(250),
+    Duration::from_millis(500),
+    Duration::from_secs(1),
+    Duration::from_secs(2),
+    Duration::from_secs(5),
+];
 
 // a route for a Service Client exposed in Zenoh as a Queryier
 #[allow(clippy::upper_case_acronyms)]
@@ -76,6 +85,10 @@ pub struct RouteServiceCli {
     // the local DDS Writer sending replies to the client
     #[serde(serialize_with = "serialize_atomic_entity_guid")]
     rep_writer: Arc<AtomicDDSEntity>,
+    // Whether the Zenoh querier currently has a matching remote server. Kept
+    // on the route so Drop can cancel an in-flight activation task.
+    #[serde(skip)]
+    matching_servers: Arc<AtomicBool>,
     // a liveliness token associated to this route, for announcement to other plugins
     #[serde(skip)]
     liveliness_token: Option<LivelinessToken>,
@@ -88,6 +101,7 @@ pub struct RouteServiceCli {
 
 impl Drop for RouteServiceCli {
     fn drop(&mut self) {
+        self.matching_servers.store(false, Ordering::Release);
         self.deactivate();
     }
 }
@@ -127,46 +141,57 @@ impl RouteServiceCli {
                 .map_err(|e| format!("Failed create Querier for key {zenoh_key_expr}: {e}",))?,
         );
 
-        let route_id = format!("Route Service Client (ROS:{ros2_name} -> Zenoh:{zenoh_key_expr}");
+        let route_id = format!("Route Service Client (ROS:{ros2_name} -> Zenoh:{zenoh_key_expr})");
 
         // activate/deactivate DDS Reader/Writer on detection/undetection of matching Subscribers
         // (copy/move all required args for the callback)
         let rep_writer: Arc<AtomicDDSEntity> = Arc::new(DDS_ENTITY_NULL.into());
         let req_reader: Arc<AtomicDDSEntity> = Arc::new(DDS_ENTITY_NULL.into());
+        let matching_servers = Arc::new(AtomicBool::new(false));
+        let activation_in_progress = Arc::new(AtomicBool::new(false));
 
         zenoh_querier
             .matching_listener()
             .callback({
                 let rep_writer = rep_writer.clone();
                 let req_reader = req_reader.clone();
+                let matching_servers = matching_servers.clone();
+                let activation_in_progress = activation_in_progress.clone();
                 let ros2_name = ros2_name.clone();
                 let ros2_type = ros2_type.clone();
                 let context = context.clone();
                 let zquerier = zenoh_querier.clone();
 
                 move |status| {
-                        tracing::debug!("{route_id} MatchingStatus changed: {status:?}");
-                        if status.matching() {
-                            if let Err(e) = activate(
-                                &rep_writer,
-                                &req_reader,
-                                &ros2_name,
-                                &ros2_type,
-                                &route_id,
-                                &context,
-                                &type_info,
-                                &zquerier,
-                            ) {
-                                tracing::error!("{route_id}: failed to activate DDS Reader: {e}");
-                            }
-                        } else {
-                            deactivate(
-                                &rep_writer,
-                                &req_reader,
-                                &route_id,
-                                &context.ros_discovery_mgr,
-                            )
+                    tracing::debug!("{route_id} MatchingStatus changed: {status:?}");
+                    if status.matching() {
+                        matching_servers.store(true, Ordering::Release);
+                        if activation_in_progress
+                            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                            .is_ok()
+                        {
+                            spawn_activation(
+                                rep_writer.clone(),
+                                req_reader.clone(),
+                                matching_servers.clone(),
+                                activation_in_progress.clone(),
+                                ros2_name.clone(),
+                                ros2_type.clone(),
+                                route_id.clone(),
+                                context.clone(),
+                                type_info.clone(),
+                                zquerier.clone(),
+                            );
                         }
+                    } else {
+                        matching_servers.store(false, Ordering::Release);
+                        deactivate(
+                            &rep_writer,
+                            &req_reader,
+                            &route_id,
+                            &context.ros_discovery_mgr,
+                        )
+                    }
                 }
             })
             .background()
@@ -182,6 +207,7 @@ impl RouteServiceCli {
             queries_timeout,
             rep_writer,
             req_reader,
+            matching_servers,
             liveliness_token: None,
             remote_routes: HashSet::new(),
             local_nodes: HashSet::new(),
@@ -290,6 +316,84 @@ impl RouteServiceCli {
 }
 
 #[allow(clippy::too_many_arguments)]
+fn spawn_activation(
+    rep_writer: Arc<AtomicDDSEntity>,
+    req_reader: Arc<AtomicDDSEntity>,
+    matching_servers: Arc<AtomicBool>,
+    activation_in_progress: Arc<AtomicBool>,
+    ros2_name: String,
+    ros2_type: String,
+    route_id: String,
+    context: Context,
+    type_info: Option<Arc<TypeInfo>>,
+    zenoh_querier: Arc<Querier<'static>>,
+) {
+    tokio::spawn(async move {
+        let mut failures = 0usize;
+
+        while matching_servers.load(Ordering::Acquire)
+            && (rep_writer.load(Ordering::Acquire) == DDS_ENTITY_NULL
+                || req_reader.load(Ordering::Acquire) == DDS_ENTITY_NULL)
+        {
+            match activate(
+                &rep_writer,
+                &req_reader,
+                &ros2_name,
+                &ros2_type,
+                &route_id,
+                &context,
+                &type_info,
+                &zenoh_querier,
+            ) {
+                Ok(()) => {
+                    if !matching_servers.load(Ordering::Acquire) {
+                        deactivate(
+                            &rep_writer,
+                            &req_reader,
+                            &route_id,
+                            &context.ros_discovery_mgr,
+                        );
+                    }
+                    break;
+                }
+                Err(e) => {
+                    let delay = DDS_SERVICE_ACTIVATION_RETRY_DELAYS
+                        [failures.min(DDS_SERVICE_ACTIVATION_RETRY_DELAYS.len() - 1)];
+                    failures = failures.saturating_add(1);
+                    tracing::error!(
+                        "{route_id}: failed to activate DDS endpoints: {e}; retrying in {delay:?}"
+                    );
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
+
+        activation_in_progress.store(false, Ordering::Release);
+
+        if matching_servers.load(Ordering::Acquire)
+            && (rep_writer.load(Ordering::Acquire) == DDS_ENTITY_NULL
+                || req_reader.load(Ordering::Acquire) == DDS_ENTITY_NULL)
+            && activation_in_progress
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+        {
+            spawn_activation(
+                rep_writer,
+                req_reader,
+                matching_servers,
+                activation_in_progress,
+                ros2_name,
+                ros2_type,
+                route_id,
+                context,
+                type_info,
+                zenoh_querier,
+            );
+        }
+    });
+}
+
+#[allow(clippy::too_many_arguments)]
 fn activate(
     rep_writer: &Arc<AtomicDDSEntity>,
     req_reader: &Arc<AtomicDDSEntity>,
@@ -324,27 +428,20 @@ fn activate(
         true,
         qos.clone(),
     )?;
-    let old = rep_writer.swap(dds_writer, Ordering::Relaxed);
-    if old != DDS_ENTITY_NULL {
-        tracing::warn!(
-            "{route_id}: on activation their was already a DDS Reply Writer - overwrite it"
-        );
-        if let Err(e) = delete_dds_entity(old) {
-            tracing::warn!("{route_id}: failed to delete overwritten DDS Reply Writer: {e}");
+    let writer_gid = match get_guid(&dds_writer) {
+        Ok(gid) => gid,
+        Err(e) => {
+            let _ = delete_dds_endpoint(dds_writer);
+            return Err(e);
         }
-    }
-
-    // add writer's GID in ros_discovery_info message
-    context
-        .ros_discovery_mgr
-        .add_dds_writer(get_guid(&dds_writer)?);
+    };
 
     // create DDS Reader to receive requests and route them to Zenoh
     let req_topic_name = format!("rq{}Request", ros2_name);
     let req_type_name = ros2_service_type_to_request_dds_type(ros2_type);
     let zquerier = zenoh_querier.clone();
     let route_id2 = route_id.to_owned();
-    let dds_reader = create_dds_reader(
+    let dds_reader = match create_dds_reader(
         context.participant,
         req_topic_name,
         req_type_name,
@@ -355,21 +452,50 @@ fn activate(
         move |sample| {
             route_dds_request_to_zenoh(&route_id2, sample, &zquerier, dds_writer);
         },
-    )?;
-    let old = req_reader.swap(dds_reader, Ordering::Relaxed);
+    ) {
+        Ok(reader) => reader,
+        Err(e) => {
+            let _ = delete_dds_endpoint(dds_writer);
+            return Err(e);
+        }
+    };
+    let reader_gid = match get_guid(&dds_reader) {
+        Ok(gid) => gid,
+        Err(e) => {
+            let _ = delete_dds_endpoint(dds_reader);
+            let _ = delete_dds_endpoint(dds_writer);
+            return Err(e);
+        }
+    };
+
+    context.ros_discovery_mgr.add_dds_writer(writer_gid);
+    context.ros_discovery_mgr.add_dds_reader(reader_gid);
+
+    let old = rep_writer.swap(dds_writer, Ordering::AcqRel);
+    if old != DDS_ENTITY_NULL {
+        tracing::warn!(
+            "{route_id}: on activation their was already a DDS Reply Writer - overwrite it"
+        );
+        if let Ok(gid) = get_guid(&old) {
+            context.ros_discovery_mgr.remove_dds_writer(gid);
+        }
+        if let Err(e) = delete_dds_endpoint(old) {
+            tracing::warn!("{route_id}: failed to delete overwritten DDS Reply Writer: {e}");
+        }
+    }
+
+    let old = req_reader.swap(dds_reader, Ordering::AcqRel);
     if old != DDS_ENTITY_NULL {
         tracing::warn!(
             "{route_id}: on activation their was already a DDS Request Reader - overwrite it"
         );
-        if let Err(e) = delete_dds_entity(old) {
+        if let Ok(gid) = get_guid(&old) {
+            context.ros_discovery_mgr.remove_dds_reader(gid);
+        }
+        if let Err(e) = delete_dds_endpoint(old) {
             tracing::warn!("{route_id}: failed to delete overwritten DDS Request Reader: {e}");
         }
     }
-
-    // add reader's GID in ros_discovery_info message
-    context
-        .ros_discovery_mgr
-        .add_dds_reader(get_guid(&dds_reader)?);
 
     Ok(())
 }
@@ -381,25 +507,25 @@ fn deactivate(
     ros_discovery_mgr: &Arc<RosDiscoveryInfoMgr>,
 ) {
     tracing::debug!("{route_id}: Deactivate");
-    let req_reader = req_reader.swap(DDS_ENTITY_NULL, Ordering::Relaxed);
+    let req_reader = req_reader.swap(DDS_ENTITY_NULL, Ordering::AcqRel);
     if req_reader != DDS_ENTITY_NULL {
         // remove reader's GID from ros_discovery_info message
         match get_guid(&req_reader) {
             Ok(gid) => ros_discovery_mgr.remove_dds_reader(gid),
             Err(e) => tracing::warn!("{route_id}: {e}"),
         }
-        if let Err(e) = delete_dds_entity(req_reader) {
+        if let Err(e) = delete_dds_endpoint(req_reader) {
             tracing::warn!("{route_id}: error deleting DDS Reader: {e}");
         }
     }
-    let rep_writer = rep_writer.swap(DDS_ENTITY_NULL, Ordering::Relaxed);
+    let rep_writer = rep_writer.swap(DDS_ENTITY_NULL, Ordering::AcqRel);
     if rep_writer != DDS_ENTITY_NULL {
         // remove writer's GID from ros_discovery_info message
         match get_guid(&rep_writer) {
             Ok(gid) => ros_discovery_mgr.remove_dds_writer(gid),
             Err(e) => tracing::warn!("{route_id}: {e}"),
         }
-        if let Err(e) = delete_dds_entity(rep_writer) {
+        if let Err(e) = delete_dds_endpoint(rep_writer) {
             tracing::warn!("{route_id}: error deleting DDS Writer: {e}");
         }
     }

--- a/zenoh-plugin-ros2dds/src/route_service_srv.rs
+++ b/zenoh-plugin-ros2dds/src/route_service_srv.rs
@@ -39,9 +39,10 @@ use crate::{
     dds_types::{DDSRawSample, TypeInfo},
     dds_utils::{
         create_dds_reader, create_dds_writer, dds_write, delete_dds_entity, get_guid,
-        get_instance_handle, is_cdr_little_endian, serialize_entity_guid, CDR_HEADER_BE,
-        CDR_HEADER_LE,
+        get_instance_handle, is_cdr_little_endian, serialize_entity_guid, serialize_local_nodes,
+        CDR_HEADER_BE, CDR_HEADER_LE,
     },
+    gid::Gid,
     liveliness_mgt::new_ke_liveliness_service_srv,
     ros2_utils::{
         is_service_for_action, new_service_id, ros2_service_type_to_reply_dds_type,
@@ -87,8 +88,9 @@ pub struct RouteServiceSrv {
     liveliness_token: Option<LivelinessToken>,
     // the list of remote routes served by this route ("<zenoh_id>:<zenoh_key_expr>"")
     remote_routes: HashSet<String>,
-    // the list of nodes served by this route
-    local_nodes: HashSet<String>,
+    // the list of nodes served by this route, keyed by (participant_gid, node_fullname) — #702.
+    #[serde(serialize_with = "serialize_local_nodes")]
+    local_nodes: HashSet<(Gid, String)>,
 }
 
 impl Drop for RouteServiceSrv {
@@ -312,24 +314,25 @@ impl RouteServiceSrv {
     }
 
     #[inline]
-    pub async fn add_local_node(&mut self, node: String) {
-        self.local_nodes.insert(node);
-        tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
-        // if 1st local node added, activate the route
-        if self.local_nodes.len() == 1 {
+    pub async fn add_local_node(&mut self, node_key: (Gid, String)) {
+        if self.local_nodes.insert(node_key) && self.local_nodes.len() == 1 {
+            tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
             if let Err(e) = self.announce_route().await {
                 tracing::error!("{self} activation failed: {e}");
             }
+        } else {
+            tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
         }
     }
 
     #[inline]
-    pub fn remove_local_node(&mut self, node: &str) {
-        self.local_nodes.remove(node);
-        tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
-        // if last local node removed, deactivate the route
-        if self.local_nodes.is_empty() {
-            self.retire_route();
+    pub fn remove_local_node(&mut self, node_key: &(Gid, String)) {
+        if self.local_nodes.remove(node_key) {
+            tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
+            // if last local node removed, deactivate the route
+            if self.local_nodes.is_empty() {
+                self.retire_route();
+            }
         }
     }
 

--- a/zenoh-plugin-ros2dds/src/route_service_srv.rs
+++ b/zenoh-plugin-ros2dds/src/route_service_srv.rs
@@ -38,7 +38,7 @@ use zenoh::{
 use crate::{
     dds_types::{DDSRawSample, TypeInfo},
     dds_utils::{
-        create_dds_reader, create_dds_writer, dds_write, delete_dds_entity, get_guid,
+        create_dds_reader, create_dds_writer, dds_write, delete_dds_endpoint, get_guid,
         get_instance_handle, is_cdr_little_endian, serialize_entity_guid, serialize_local_nodes,
         CDR_HEADER_BE, CDR_HEADER_LE,
     },
@@ -106,10 +106,10 @@ impl Drop for RouteServiceSrv {
             Err(e) => tracing::warn!("{self}: {e}"),
         }
 
-        if let Err(e) = delete_dds_entity(self.req_writer) {
+        if let Err(e) = delete_dds_endpoint(self.req_writer) {
             tracing::warn!("{}: error deleting DDS Writer:  {}", self, e);
         }
-        if let Err(e) = delete_dds_entity(self.rep_reader) {
+        if let Err(e) = delete_dds_endpoint(self.rep_reader) {
             tracing::warn!("{}: error deleting DDS Reader:  {}", self, e);
         }
     }
@@ -157,13 +157,25 @@ impl RouteServiceSrv {
             qos.clone(),
         )?;
         // add writer's GID in ros_discovery_info message
-        context
-            .ros_discovery_mgr
-            .add_dds_writer(get_guid(&req_writer)?);
+        let req_writer_gid = match get_guid(&req_writer) {
+            Ok(gid) => gid,
+            Err(e) => {
+                let _ = delete_dds_endpoint(req_writer);
+                return Err(e);
+            }
+        };
+        context.ros_discovery_mgr.add_dds_writer(req_writer_gid);
 
         // client_guid used in requests; use dds_instance_handle of writer as rmw_cyclonedds here:
         // https://github.com/ros2/rmw_cyclonedds/blob/2263814fab142ac19dd3395971fb1f358d22a653/rmw_cyclonedds_cpp/src/rmw_node.cpp#L4848
-        let client_guid = get_instance_handle(req_writer)?;
+        let client_guid = match get_instance_handle(req_writer) {
+            Ok(guid) => guid,
+            Err(e) => {
+                context.ros_discovery_mgr.remove_dds_writer(req_writer_gid);
+                let _ = delete_dds_endpoint(req_writer);
+                return Err(e);
+            }
+        };
 
         tracing::debug!(
             "{route_id}: (local client_guid={client_guid:02x?})  id='{client_id_str}' => USER_DATA={:?}",
@@ -177,7 +189,7 @@ impl RouteServiceSrv {
         // create DDS Reader to receive replies and route them to Zenoh
         let rep_topic_name = format!("rr{ros2_name}Reply");
         let rep_type_name = ros2_service_type_to_reply_dds_type(&ros2_type);
-        let rep_reader = create_dds_reader(
+        let rep_reader = match create_dds_reader(
             context.participant,
             rep_topic_name,
             rep_type_name,
@@ -197,11 +209,25 @@ impl RouteServiceSrv {
                     );
                 }
             },
-        )?;
+        ) {
+            Ok(reader) => reader,
+            Err(e) => {
+                context.ros_discovery_mgr.remove_dds_writer(req_writer_gid);
+                let _ = delete_dds_endpoint(req_writer);
+                return Err(e);
+            }
+        };
         // add reader's GID in ros_discovery_info message
-        context
-            .ros_discovery_mgr
-            .add_dds_reader(get_guid(&rep_reader)?);
+        let rep_reader_gid = match get_guid(&rep_reader) {
+            Ok(gid) => gid,
+            Err(e) => {
+                let _ = delete_dds_endpoint(rep_reader);
+                context.ros_discovery_mgr.remove_dds_writer(req_writer_gid);
+                let _ = delete_dds_endpoint(req_writer);
+                return Err(e);
+            }
+        };
+        context.ros_discovery_mgr.add_dds_reader(rep_reader_gid);
 
         Ok(RouteServiceSrv {
             ros2_name,

--- a/zenoh-plugin-ros2dds/src/route_subscriber.rs
+++ b/zenoh-plugin-ros2dds/src/route_subscriber.rs
@@ -31,8 +31,9 @@ use zenoh_ext::{AdvancedSubscriber, AdvancedSubscriberBuilderExt, HistoryConfig}
 use crate::{
     dds_utils::{
         create_dds_writer, ddsrt_iov_len_from_usize, delete_dds_entity, get_guid,
-        serialize_entity_guid,
+        serialize_entity_guid, serialize_local_nodes,
     },
+    gid::Gid,
     liveliness_mgt::new_ke_liveliness_sub,
     qos::{History, Qos},
     qos_helpers::is_transient_local,
@@ -78,8 +79,10 @@ pub struct RouteSubscriber {
     liveliness_token: Option<LivelinessToken>,
     // the list of remote routes served by this route ("<zenoh_id>:<zenoh_key_expr>"")
     remote_routes: HashSet<String>,
-    // the list of nodes served by this route
-    local_nodes: HashSet<String>,
+    // the list of nodes served by this route, keyed by (participant_gid, node_fullname) to
+    // disambiguate same-named nodes across restarts (#702).
+    #[serde(serialize_with = "serialize_local_nodes")]
+    local_nodes: HashSet<(Gid, String)>,
 }
 
 impl Drop for RouteSubscriber {
@@ -281,24 +284,31 @@ impl RouteSubscriber {
     }
 
     #[inline]
-    pub async fn add_local_node(&mut self, entity_key: String, discovered_reader_qos: &Qos) {
-        self.local_nodes.insert(entity_key);
-        tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
-        // if 1st local node added, activate the route
-        if self.local_nodes.len() == 1 {
+    pub async fn add_local_node(
+        &mut self,
+        node_key: (Gid, String),
+        discovered_reader_qos: &Qos,
+    ) {
+        // Only activate on the transition from 0 to 1 entries — re-inserting an existing key
+        // must NOT re-run announce_route (was a subtle bug, mirrored from RoutePublisher's fix).
+        if self.local_nodes.insert(node_key) && self.local_nodes.len() == 1 {
+            tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
             if let Err(e) = self.announce_route(discovered_reader_qos).await {
                 tracing::error!("{self} activation failed: {e}");
             }
+        } else {
+            tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
         }
     }
 
     #[inline]
-    pub fn remove_local_node(&mut self, entity_key: &str) {
-        self.local_nodes.remove(entity_key);
-        tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
-        // if last local node removed, deactivate the route
-        if self.local_nodes.is_empty() {
-            self.retire_route();
+    pub fn remove_local_node(&mut self, node_key: &(Gid, String)) {
+        if self.local_nodes.remove(node_key) {
+            tracing::debug!("{self} now serving local nodes {:?}", self.local_nodes);
+            // if last local node removed, deactivate the route
+            if self.local_nodes.is_empty() {
+                self.retire_route();
+            }
         }
     }
 

--- a/zenoh-plugin-ros2dds/src/route_subscriber.rs
+++ b/zenoh-plugin-ros2dds/src/route_subscriber.rs
@@ -30,7 +30,7 @@ use zenoh_ext::{AdvancedSubscriber, AdvancedSubscriberBuilderExt, HistoryConfig}
 
 use crate::{
     dds_utils::{
-        create_dds_writer, ddsrt_iov_len_from_usize, delete_dds_entity, get_guid,
+        create_dds_writer, ddsrt_iov_len_from_usize, delete_dds_endpoint, get_guid,
         serialize_entity_guid, serialize_local_nodes,
     },
     gid::Gid,
@@ -41,6 +41,14 @@ use crate::{
     routes_mgr::Context,
     serialize_option_as_bool, vec_into_raw_parts, LOG_PAYLOAD,
 };
+
+const DDS_WRITER_CREATION_RETRY_DELAYS: [Duration; 5] = [
+    Duration::from_millis(100),
+    Duration::from_millis(250),
+    Duration::from_millis(500),
+    Duration::from_secs(1),
+    Duration::from_secs(2),
+];
 
 enum ZSubscriber {
     Subscriber(Subscriber<()>),
@@ -94,7 +102,7 @@ impl Drop for RouteSubscriber {
         }
 
         tracing::debug!("{self}: delete Writer");
-        if let Err(e) = delete_dds_entity(self.dds_writer) {
+        if let Err(e) = delete_dds_endpoint(self.dds_writer) {
             tracing::warn!("{}: error deleting DDS Reader:  {}", self, e);
         }
     }
@@ -141,17 +149,24 @@ impl RouteSubscriber {
         tracing::debug!(
             "Route Subscriber ({zenoh_key_expr} -> {ros2_name}): create Writer with {writer_qos:?}"
         );
-        let dds_writer = create_dds_writer(
+        let dds_writer = create_dds_writer_with_retry(
             context.participant,
             topic_name,
             type_name,
             keyless,
             writer_qos,
-        )?;
+            &format!("Route Subscriber (Zenoh:{zenoh_key_expr} -> ROS:{ros2_name})"),
+        )
+        .await?;
         // add writer's GID in ros_discovery_info message
-        context
-            .ros_discovery_mgr
-            .add_dds_writer(get_guid(&dds_writer)?);
+        let writer_gid = match get_guid(&dds_writer) {
+            Ok(gid) => gid,
+            Err(e) => {
+                let _ = delete_dds_endpoint(dds_writer);
+                return Err(e);
+            }
+        };
+        context.ros_discovery_mgr.add_dds_writer(writer_gid);
 
         Ok(RouteSubscriber {
             ros2_name,
@@ -284,11 +299,7 @@ impl RouteSubscriber {
     }
 
     #[inline]
-    pub async fn add_local_node(
-        &mut self,
-        node_key: (Gid, String),
-        discovered_reader_qos: &Qos,
-    ) {
+    pub async fn add_local_node(&mut self, node_key: (Gid, String), discovered_reader_qos: &Qos) {
         // Only activate on the transition from 0 to 1 entries — re-inserting an existing key
         // must NOT re-run announce_route (was a subtle bug, mirrored from RoutePublisher's fix).
         if self.local_nodes.insert(node_key) && self.local_nodes.len() == 1 {
@@ -320,6 +331,38 @@ impl RouteSubscriber {
     #[inline]
     pub fn is_unused(&self) -> bool {
         !self.is_serving_local_node() && !self.is_serving_remote_route()
+    }
+}
+
+async fn create_dds_writer_with_retry(
+    participant: dds_entity_t,
+    topic_name: String,
+    type_name: String,
+    keyless: bool,
+    writer_qos: Qos,
+    route_id: &str,
+) -> Result<dds_entity_t, String> {
+    let mut failures = 0usize;
+
+    loop {
+        match create_dds_writer(
+            participant,
+            topic_name.clone(),
+            type_name.clone(),
+            keyless,
+            writer_qos.clone(),
+        ) {
+            Ok(writer) => return Ok(writer),
+            Err(e) if failures < DDS_WRITER_CREATION_RETRY_DELAYS.len() => {
+                let delay = DDS_WRITER_CREATION_RETRY_DELAYS[failures];
+                failures += 1;
+                tracing::warn!(
+                    "{route_id}: failed to create DDS Writer: {e}; retrying in {delay:?}"
+                );
+                tokio::time::sleep(delay).await;
+            }
+            Err(e) => return Err(e),
+        }
     }
 }
 

--- a/zenoh-plugin-ros2dds/src/routes_mgr.rs
+++ b/zenoh-plugin-ros2dds/src/routes_mgr.rs
@@ -135,7 +135,7 @@ impl RoutesMgr {
     ) -> Result<(), String> {
         use ROS2DiscoveryEvent::*;
         match event {
-            DiscoveredMsgPub(node, iface) => {
+            DiscoveredMsgPub(participant, node, iface) => {
                 // Pick 1 discovered Writer amongst the possibly multiple ones listed in MsgPub
                 let entity = {
                     let entities = zread!(self.context.discovered_entities);
@@ -157,7 +157,7 @@ impl RoutesMgr {
                                 true,
                             )
                             .await?;
-                        route.add_local_node(node, &entity.qos).await;
+                        route.add_local_node((participant, node), &entity.qos).await;
                     }
                     None => {
                         return Err(format!(
@@ -168,11 +168,11 @@ impl RoutesMgr {
                 }
             }
 
-            UndiscoveredMsgPub(node, iface) => {
+            UndiscoveredMsgPub(participant, node, iface) => {
                 if let Entry::Occupied(mut entry) = self.routes_publishers.entry(iface.name.clone())
                 {
                     let route = entry.get_mut();
-                    route.remove_local_node(&node);
+                    route.remove_local_node(&(participant, node));
                     if route.is_unused() {
                         self.admin_space
                             .remove(&(*KE_PREFIX_ROUTE_PUBLISHER / iface.name_as_keyexpr()));
@@ -182,7 +182,7 @@ impl RoutesMgr {
                 }
             }
 
-            DiscoveredMsgSub(node, iface) => {
+            DiscoveredMsgSub(participant, node, iface) => {
                 // Pick 1 discovered Reader amongst the possibly multiple ones listed in MsgSub
                 let entity = {
                     let entities = zread!(self.context.discovered_entities);
@@ -204,7 +204,7 @@ impl RoutesMgr {
                                 true,
                             )
                             .await?;
-                        route.add_local_node(node, &entity.qos).await;
+                        route.add_local_node((participant, node), &entity.qos).await;
                     }
                     None => {
                         return Err(format!(
@@ -215,12 +215,12 @@ impl RoutesMgr {
                 }
             }
 
-            UndiscoveredMsgSub(node, iface) => {
+            UndiscoveredMsgSub(participant, node, iface) => {
                 if let Entry::Occupied(mut entry) =
                     self.routes_subscribers.entry(iface.name.clone())
                 {
                     let route = entry.get_mut();
-                    route.remove_local_node(&node);
+                    route.remove_local_node(&(participant, node));
                     if route.is_unused() {
                         self.admin_space
                             .remove(&(*KE_PREFIX_ROUTE_SUBSCRIBER / iface.name_as_keyexpr()));
@@ -229,19 +229,19 @@ impl RoutesMgr {
                     }
                 }
             }
-            DiscoveredServiceSrv(node, iface) => {
+            DiscoveredServiceSrv(participant, node, iface) => {
                 // Get route (create it if not yet exists)
                 let route = self
                     .get_or_create_route_service_srv(iface.name, iface.typ, true)
                     .await?;
-                route.add_local_node(node).await;
+                route.add_local_node((participant, node)).await;
             }
-            UndiscoveredServiceSrv(node, iface) => {
+            UndiscoveredServiceSrv(participant, node, iface) => {
                 if let Entry::Occupied(mut entry) =
                     self.routes_service_srv.entry(iface.name.clone())
                 {
                     let route = entry.get_mut();
-                    route.remove_local_node(&node);
+                    route.remove_local_node(&(participant, node));
                     if route.is_unused() {
                         self.admin_space
                             .remove(&(*KE_PREFIX_ROUTE_SERVICE_SRV / iface.name_as_keyexpr()));
@@ -250,19 +250,19 @@ impl RoutesMgr {
                     }
                 }
             }
-            DiscoveredServiceCli(node, iface) => {
+            DiscoveredServiceCli(participant, node, iface) => {
                 // Get route (create it if not yet exists)
                 let route = self
                     .get_or_create_route_service_cli(iface.name, iface.typ, true)
                     .await?;
-                route.add_local_node(node).await;
+                route.add_local_node((participant, node)).await;
             }
-            UndiscoveredServiceCli(node, iface) => {
+            UndiscoveredServiceCli(participant, node, iface) => {
                 if let Entry::Occupied(mut entry) =
                     self.routes_service_cli.entry(iface.name.clone())
                 {
                     let route = entry.get_mut();
-                    route.remove_local_node(&node);
+                    route.remove_local_node(&(participant, node));
                     if route.is_unused() {
                         self.admin_space
                             .remove(&(*KE_PREFIX_ROUTE_SERVICE_CLI / iface.name_as_keyexpr()));
@@ -271,18 +271,18 @@ impl RoutesMgr {
                     }
                 }
             }
-            DiscoveredActionSrv(node, iface) => {
+            DiscoveredActionSrv(participant, node, iface) => {
                 // Get route (create it if not yet exists)
                 let route = self
                     .get_or_create_route_action_srv(iface.name, iface.typ)
                     .await?;
-                route.add_local_node(node).await;
+                route.add_local_node((participant, node)).await;
             }
-            UndiscoveredActionSrv(node, iface) => {
+            UndiscoveredActionSrv(participant, node, iface) => {
                 if let Entry::Occupied(mut entry) = self.routes_action_srv.entry(iface.name.clone())
                 {
                     let route = entry.get_mut();
-                    route.remove_local_node(&node);
+                    route.remove_local_node(&(participant, node));
                     if route.is_unused() {
                         self.admin_space
                             .remove(&(*KE_PREFIX_ROUTE_ACTION_SRV / iface.name_as_keyexpr()));
@@ -291,18 +291,18 @@ impl RoutesMgr {
                     }
                 }
             }
-            DiscoveredActionCli(node, iface) => {
+            DiscoveredActionCli(participant, node, iface) => {
                 // Get route (create it if not yet exists)
                 let route = self
                     .get_or_create_route_action_cli(iface.name, iface.typ)
                     .await?;
-                route.add_local_node(node).await;
+                route.add_local_node((participant, node)).await;
             }
-            UndiscoveredActionCli(node, iface) => {
+            UndiscoveredActionCli(participant, node, iface) => {
                 if let Entry::Occupied(mut entry) = self.routes_action_cli.entry(iface.name.clone())
                 {
                     let route = entry.get_mut();
-                    route.remove_local_node(&node);
+                    route.remove_local_node(&(participant, node));
                     if route.is_unused() {
                         self.admin_space
                             .remove(&(*KE_PREFIX_ROUTE_ACTION_CLI / iface.name_as_keyexpr()));


### PR DESCRIPTION
## Summary

Fixes **#702** (subscriber route stuck `is_active: false` after a same-named ROS 2 node restarts) and **part of #703** (Bad Parameter storm from leaked CStrings during rapid create/destroy churn).

The two bugs reinforce each other in practice: the #702 same-name race corrupts cyclonedds state on the publisher-side bridge, which then triggers a flood of `failed to activate DDS Reader: Bad Parameter` errors — exactly the #703 symptom — but in **minutes** instead of the hours the original #703 report needed.

## Root cause

### #702 — `local_nodes` keyed on node fullname only

Every route type (`RouteSubscriber`, `RoutePublisher`, service srv/cli, action srv/cli) tracked its serving nodes in:

```rust
local_nodes: HashSet<String>   // node fullname only
```

When a ROS 2 node restarts with the **same name** but a **new participant GID**, the bridge processes two events:

1. **ADD** for the new participant's reader/writer → `route.add_local_node("/zephyr")`
2. **DISPOSE** for the old participant's reader/writer → `route.remove_local_node("/zephyr")`

If the DISPOSE arrives after the ADD (common), it removes the entry the new participant just inserted. The route deactivates and never recovers because subsequent events for the new participant key into the (now empty) set as if the node had already been added.

The bridge's `ros2/node/<participant_gid>/...` admin space stayed consistent because it was already keyed by participant GID. Only `local_nodes` lost the race.

### #703 — CString leaks in `create_topic` / `create_dds_writer`

Both functions did:

```rust
let cton = CString::new(topic_name).unwrap().into_raw();
let ctyn = CString::new(type_name).unwrap().into_raw();
// ...hand to cyclonedds...
// no matching CString::from_raw — leaks every call
```

cyclonedds copies the strings internally, so freeing immediately after the create call is safe — and is exactly what `ros_discovery.rs:171-172` already does.

## Fix

Two commits, each independently reviewable:

1. **`fix(#703): release CString memory after DDS topic and writer creation`** — `dds_utils.rs` only. Adds `drop(CString::from_raw(...))` in both branches of `create_topic` and after `dds_create_writer`. Mirrors the existing cleanup pattern in `ros_discovery.rs`.

2. **`fix(#702): key local_nodes by (participant_gid, node_fullname)`** — the main change:
   - Adds a `Gid` (participant) to every `ROS2DiscoveryEvent` variant.
   - Adds a `participant: Gid` field on `NodeInfo` and threads it through every emitted Discovered*/Undiscovered* event.
   - Changes `local_nodes` to `HashSet<(Gid, String)>` in all 6 route types.
   - Custom `serialize_local_nodes` keeps the admin-space JSON format unchanged (still a deduplicated array of node fullname strings — participant GID is internal).
   - Also fixes a secondary issue in `RouteSubscriber::add_local_node` which used `if self.local_nodes.len() == 1` after an unconditional insert, so re-inserting an existing key would incorrectly re-run `announce_route`. Now matches `RoutePublisher`'s correct 0→1-transition pattern.

## How we tested

A docker-compose-based reproducer (not included in this PR — happy to send as a follow-up if useful) that runs entirely on plain Docker bridge networks, no host networking:

- **`bridge-a`** — `zenoh-bridge-ros2dds` in **router** mode, REST admin enabled on `:8000`. On `ros-a` network with `ROS_DOMAIN_ID=42`.
- **`bridge-b`** — `zenoh-bridge-ros2dds` in **client** mode, connecting to `bridge-a` over TCP/7447. On `ros-b` network with `ROS_DOMAIN_ID=43`.
- **`publisher-b`** — ROS 2 node named `zephyr` publishing `std_msgs/String` on `/gripper/button/left`, on the `ros-b` network.
- **`subscriber-a`** — driver loop that **restarts a same-named ROS 2 node `zephyr`** every ~2 s, subscribing to the same topic, on the `ros-a` network.
- **`probe`** — polls `bridge-a`'s REST admin space every 1 s for `~/ros2/route/topic/sub/...` and `~/ros2/route/topic/pub/...`; exits **0** once 5 consecutive probes show both routes healthy (`local_nodes` and `remote_routes` populated, `dds_reader` non-empty), exits **1** after 90 s otherwise.

Different `ROS_DOMAIN_ID` values on either side force the topic across the two bridges — no DDS shortcut. Both sides naming their node `zephyr` makes the bookkeeping race that #702 describes easy to hit, and (in our run) reliably also triggers the #703 publisher-side `Bad Parameter` storm within seconds.

## Verification

### Before the fix — `eclipse/zenoh-bridge-ros2dds:1.9.0`

**Probe never reaches healthy state across the full 90 s window:**
```
probe 86: sub[active=True local=['/zephyr'] remote=[]] pub[reader=set local=[] remote=['56ca...:gripper/button/left']] node_has_subscriber=True
probe 87: sub[active=True local=['/zephyr'] remote=[]] pub[reader=set local=[] remote=['56ca...:gripper/button/left']] node_has_subscriber=True
probe 88: sub[active=True local=['/zephyr'] remote=[]] pub[reader=set local=[] remote=['56ca...:gripper/button/left']] node_has_subscriber=True
probe 89: sub[active=True local=['/zephyr'] remote=[]] pub[reader=set local=[] remote=['56ca...:gripper/button/left']] node_has_subscriber=True
not reproduced within probe window (and never reached healthy state)
probe-1 exited with code 1
```

Note **pub side**: `local=[]` (the local zephyr publisher *should* be tracked here) while `remote=[...]` is correctly populated. This is the bridge-b mirror of #702 — the publisher-side route knows the remote subscriber exists but does not realize a local publisher node exists, so the routed `dds_reader` never matches a usable local entity and **no messages flow**.

**Subscriber never receives a single message** across 36 same-name restarts:
```
[INFO] [zephyr]: received 0 messages
[INFO] [zephyr]: received 0 messages
[INFO] [zephyr]: received 0 messages
... (every single restart)
```

**Bridge-b logs (earlier longer run): 12,675 occurrences of `Error creating DDS Reader: Bad Parameter`** in a few minutes, with the matching listener thrashing in a tight loop because activation kept failing but the matching status was never cleared.

### After the fix — image built from this branch

**Probe reaches healthy state within seconds:**
```
probe 00: sub[active=True local=['/zephyr'] remote=['ee18...:gripper/button/left']] pub[reader=set local=['/zephyr'] remote=['f49b...:gripper/button/left']] node_has_subscriber=True
probe 01: sub[active=False local=[] remote=['ee18...:gripper/button/left']] pub[reader=empty local=['/zephyr'] remote=[]] node_has_subscriber=False    ← subscriber restart in progress
probe 02: sub[active=True local=['/zephyr'] remote=['ee18...:gripper/button/left']] pub[reader=set local=['/zephyr'] remote=['f49b...:gripper/button/left']] node_has_subscriber=True    ← auto-recovers
probe 03-05: healthy
HEALTHY: route flow steady — sub active with local+remote, pub has dds_reader, both populated
probe-1 exited with code 0
```

Note **pub side after fix**: `local=['/zephyr']` is correctly populated — the bridge now recognises the same-named local publisher as a distinct instance from any prior instance.

**Subscriber receives messages from the first restart onward:**
```
[INFO] [zephyr]: first message: button 0
[INFO] [zephyr]: received 9 messages
[INFO] [zephyr]: first message: button 12
[INFO] [zephyr]: received 10 messages
[INFO] [zephyr]: first message: button 25
```

**`Bad Parameter` errors: 0** (vs. 12,675 against `1.9.0`).

| Metric | `eclipse/zenoh-bridge-ros2dds:1.9.0` | This branch |
|---|---|---|
| Subscriber message count | 0 (all 36 restarts) | 9 → 10 → ... continuously |
| Pub route `local_nodes` | `[]` | `['/zephyr']` |
| Pub route `dds_reader` | `set` but useless (no local) | `set`, working |
| `Bad Parameter` errors | **12,675** | **0** |
| `HEALTHY` reached | never (90 s window) | within 5 s |
| Probe exit code | 1 | 0 |

## Notes on scope

- `dds_utils.rs` also contains a `Box::into_raw` leak for listener callbacks in `create_dds_reader` (the other half of #703). That fix requires changing the listener-arg type to be erased uniformly and touching `RoutePublisher::activate/deactivate_dds_reader` — held back to a follow-up PR to keep this one reviewable. The CString half of #703 is fixed here; the Box half remains a slow leak under churn but no longer compounds with the #702 race-induced storm.
- The admin-space JSON format is unchanged — verified manually against the same REST queries (`@/<zid>/ros2/route/topic/sub/...` and `@/<zid>/ros2/route/topic/pub/...`).
- All workspace `cargo check` / `cargo build --release` succeed.

## Test plan
- [x] `cargo check --workspace` clean
- [x] `cargo build --release -p zenoh-bridge-ros2dds` clean
- [x] Repro: probe exits 0 (healthy) against fix image
- [x] Repro: probe exits 1 (not reproduced) against `eclipse/zenoh-bridge-ros2dds:1.9.0`
- [x] Bridge logs show 0 `Bad Parameter` after fix (vs. ~12k against v1.9.0)
- [x] Admin-space JSON shape unchanged
- [ ] Long-run (`valgrind` / hours) to confirm CString leak elimination — not done here; relying on code review for that part.