### PR TITLE
chore: use windows-2022 image for cmake 3.31

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest, windows-2022]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install cmake
         uses: jwlawson/actions-setup-cmake@v2
         with:
-          cmake-version: '3.31.x'
+          cmake-version: "3.31.x"
 
       - name: Install ACL
         if: startsWith(matrix.os,'ubuntu')
@@ -97,40 +97,40 @@ jobs:
     container:
       image: rostooling/setup-ros-docker:ubuntu-jammy-ros-humble-ros-base-latest
     steps:
-    - uses: ros-tooling/setup-ros@v0.7
-      with:
-        required-ros-distributions: humble
+      - uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: humble
 
-    - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
 
-    # cyclors 0.2.6 does not compile with cmake 4
-    - name: Install cmake
-      uses: jwlawson/actions-setup-cmake@v2
-      with:
-        cmake-version: '3.31.x'
+      # cyclors 0.2.6 does not compile with cmake 4
+      - name: Install cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: "3.31.x"
 
-    - name: Install ACL
-      run: sudo apt-get -y install libacl1-dev
+      - name: Install ACL
+        run: sudo apt-get -y install libacl1-dev
 
-    - name: Copy rust-toolchain.toml and Cargo.lock to zenoh-test-ros2dds
-      shell: bash
-      run: 'cp rust-toolchain.toml Cargo.lock zenoh-test-ros2dds/'
-    # We need this to align the Zenoh version in zenoh-test-ros2dds with zenoh-plugin-ros2dds
-    - name: Align zenoh version in zenoh-test-ros2dds
-      shell: bash
-      run: 'sudo apt-get -y install python3-tomlkit && cd zenoh-test-ros2dds && python3 align_zenoh.py'
-    - name: Code format check
-      shell: bash
-      run: 'source /opt/ros/humble/setup.bash && cd zenoh-test-ros2dds && cargo fmt --check -- --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate"'
-    - name: Clippy
-      shell: bash
-      run: "source /opt/ros/humble/setup.bash && cd zenoh-test-ros2dds && cargo clippy --tests -- --deny warnings"
+      - name: Copy rust-toolchain.toml and Cargo.lock to zenoh-test-ros2dds
+        shell: bash
+        run: "cp rust-toolchain.toml Cargo.lock zenoh-test-ros2dds/"
+      # We need this to align the Zenoh version in zenoh-test-ros2dds with zenoh-plugin-ros2dds
+      - name: Align zenoh version in zenoh-test-ros2dds
+        shell: bash
+        run: "sudo apt-get -y install python3-tomlkit && cd zenoh-test-ros2dds && python3 align_zenoh.py"
+      - name: Code format check
+        shell: bash
+        run: 'source /opt/ros/humble/setup.bash && cd zenoh-test-ros2dds && cargo fmt --check -- --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate"'
+      - name: Clippy
+        shell: bash
+        run: "source /opt/ros/humble/setup.bash && cd zenoh-test-ros2dds && cargo clippy --tests -- --deny warnings"
 
-    - name: Run ROS tests
-      shell: bash
-      # Note that we limit only one test item tested at the same time to avoid the confliction between bridges
-      run: "source /opt/ros/humble/setup.bash && cd zenoh-test-ros2dds && cargo test --verbose"
+      - name: Run ROS tests
+        shell: bash
+        # Note that we limit only one test item tested at the same time to avoid the confliction between bridges
+        run: "source /opt/ros/humble/setup.bash && cd zenoh-test-ros2dds && cargo test --verbose"
 
   system_tests_with_ros2_jazzy:
     name: System tests with ROS 2 Jazzy
@@ -138,40 +138,40 @@ jobs:
     container:
       image: rostooling/setup-ros-docker:ubuntu-noble-ros-jazzy-ros-base-latest
     steps:
-    - uses: ros-tooling/setup-ros@v0.7
-      with:
-        required-ros-distributions: jazzy
+      - uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: jazzy
 
-    - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
 
-    # cyclors 0.2.6 does not compile with cmake 4
-    - name: Install cmake
-      uses: jwlawson/actions-setup-cmake@v2
-      with:
-        cmake-version: '3.31.x'
+      # cyclors 0.2.6 does not compile with cmake 4
+      - name: Install cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: "3.31.x"
 
-    - name: Install ACL
-      run: sudo apt-get -y install libacl1-dev
+      - name: Install ACL
+        run: sudo apt-get -y install libacl1-dev
 
-    - name: Copy rust-toolchain.toml and Cargo.lock to zenoh-test-ros2dds
-      shell: bash
-      run: 'cp rust-toolchain.toml Cargo.lock zenoh-test-ros2dds/'
-    # We need this to align the Zenoh version in zenoh-test-ros2dds with zenoh-plugin-ros2dds
-    - name: Align zenoh version in zenoh-test-ros2dds
-      shell: bash
-      run: 'sudo apt-get -y install python3-tomlkit && cd zenoh-test-ros2dds && python3 align_zenoh.py'
-    - name: Code format check
-      shell: bash
-      run: 'source /opt/ros/jazzy/setup.bash && cd zenoh-test-ros2dds && cargo fmt --check -- --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate"'
-    - name: Clippy
-      shell: bash
-      run: "source /opt/ros/jazzy/setup.bash && cd zenoh-test-ros2dds && cargo clippy --tests -- --deny warnings"
+      - name: Copy rust-toolchain.toml and Cargo.lock to zenoh-test-ros2dds
+        shell: bash
+        run: "cp rust-toolchain.toml Cargo.lock zenoh-test-ros2dds/"
+      # We need this to align the Zenoh version in zenoh-test-ros2dds with zenoh-plugin-ros2dds
+      - name: Align zenoh version in zenoh-test-ros2dds
+        shell: bash
+        run: "sudo apt-get -y install python3-tomlkit && cd zenoh-test-ros2dds && python3 align_zenoh.py"
+      - name: Code format check
+        shell: bash
+        run: 'source /opt/ros/jazzy/setup.bash && cd zenoh-test-ros2dds && cargo fmt --check -- --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate"'
+      - name: Clippy
+        shell: bash
+        run: "source /opt/ros/jazzy/setup.bash && cd zenoh-test-ros2dds && cargo clippy --tests -- --deny warnings"
 
-    - name: Run ROS tests
-      shell: bash
-      # Note that we limit only one test item tested at the same time to avoid the confliction between bridges
-      run: "source /opt/ros/jazzy/setup.bash && cd zenoh-test-ros2dds && cargo test --verbose"
+      - name: Run ROS tests
+        shell: bash
+        # Note that we limit only one test item tested at the same time to avoid the confliction between bridges
+        run: "source /opt/ros/jazzy/setup.bash && cd zenoh-test-ros2dds && cargo test --verbose"
 
   markdown_lint:
     runs-on: ubuntu-latest
@@ -179,8 +179,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DavidAnson/markdownlint-cli2-action@v18
         with:
-          config: '.markdownlint.yaml'
-          globs: '**/README.md'
+          config: ".markdownlint.yaml"
+          globs: "**/README.md"
 
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged
@@ -190,7 +190,13 @@ jobs:
   ci:
     name: CI status checks
     runs-on: ubuntu-latest
-    needs: [build, system_tests_with_ros2_humble, system_tests_with_ros2_jazzy, markdown_lint]
+    needs:
+      [
+        build,
+        system_tests_with_ros2_humble,
+        system_tests_with_ros2_jazzy,
+        markdown_lint,
+      ]
     if: always()
     steps:
       - name: Check whether all jobs pass


### PR DESCRIPTION
The windows-latest runner updates the VS tooling in the runner to an incompatible version with cmake 3 required by cyclors dependency. 

Fix https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/actions/runs/27338442029/job/80768658080?pr=706