### PR TITLE
chore: drop cmake3 install and update cyclors to 0.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # cyclors 0.2.6 does not compile with cmake 4
-      - name: Install cmake
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: '3.31.x'
-
       - name: Install ACL
         if: startsWith(matrix.os,'ubuntu')
         run: sudo apt-get -y install libacl1-dev
@@ -83,7 +77,7 @@ jobs:
         run: cargo build -p zenoh-plugin-ros2dds --features prefix_symbols --verbose --all-targets
 
       - name: Build zenoh-bridge-ros2dds
-        run: cargo build -p zenoh-bridge-ros2dds  --verbose --all-targets
+        run: cargo build -p zenoh-bridge-ros2dds --verbose --all-targets
 
       - name: Build zenoh-bridge-ros2dds (with dds_shm)
         if: ${{ !startsWith(matrix.os, 'windows') }}
@@ -114,12 +108,6 @@ jobs:
 
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
-
-    # cyclors 0.2.6 does not compile with cmake 4
-    - name: Install cmake
-      uses: jwlawson/actions-setup-cmake@v2
-      with:
-        cmake-version: '3.31.x'
 
     - name: Install ACL
       run: sudo apt-get -y install libacl1-dev

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ async-trait = "0.1.66"
 bincode = "1.3.3"
 cdr = "0.2.4"
 clap = "4.4.11"
-cyclors = "=0.3.10"
+cyclors = "0.4.0"
 derivative = "2.2.0"
 flume = "0.11.0"
 futures = "0.3.26"
@@ -46,16 +46,16 @@ tracing = "0.1"
 zenoh = { version = "1.9.0", features = [
   "plugins",
   "unstable",
-] , git = "https://github.com/eclipse-zenoh/zenoh.git" , branch = "main" }
-zenoh-config = { version = "1.9.0", default-features = false , git = "https://github.com/eclipse-zenoh/zenoh.git" , branch = "main" }
+], git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
+zenoh-config = { version = "1.9.0", default-features = false, git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 zenoh-ext = { version = "1.9.0", features = [
   "unstable",
-] , git = "https://github.com/eclipse-zenoh/zenoh.git" , branch = "main" }
+], git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 zenoh-plugin-ros2dds = { version = "1.9.0", path = "zenoh-plugin-ros2dds/", default-features = false }
 zenoh-plugin-rest = { version = "1.9.0", default-features = false, features = [
   "static_plugin",
-] , git = "https://github.com/eclipse-zenoh/zenoh.git" , branch = "main" }
-zenoh-plugin-trait = { version = "1.9.0", default-features = false , git = "https://github.com/eclipse-zenoh/zenoh.git" , branch = "main" }
+], git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
+zenoh-plugin-trait = { version = "1.9.0", default-features = false, git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
- update cyclors to 0.4.0
- drop cmake3 from CI workflow

Supersedes https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/pull/707 and should allow https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/pull/706 to succeed.

