### PR TITLE
fix: dedupe gids staged as undiscovered in update_node_info

### DIFF
--- a/zenoh-plugin-ros2dds/src/discovered_entities.rs
+++ b/zenoh-plugin-ros2dds/src/discovered_entities.rs
@@ -349,7 +349,7 @@ impl DiscoveredEntities {
                     );
                     events.push(e)
                 };
-            } else {
+            } else if !node.undiscovered_reader.contains(rgid) {
                 tracing::debug!(
                     "ROS Node {ros_node_info} declares a not yet discovered DDS Reader: {rgid}"
                 );
@@ -370,7 +370,7 @@ impl DiscoveredEntities {
                     );
                     events.push(e)
                 };
-            } else {
+            } else if !node.undiscovered_writer.contains(wgid) {
                 tracing::debug!(
                     "ROS Node {ros_node_info} declares a not yet discovered DDS Writer: {wgid}"
                 );


### PR DESCRIPTION
`update_node_info()` stages a gid into `undiscovered_reader` / `undiscovered_writer` with an unconditional push, and only removes it once the matching DDS endpoint is discovered. A node that keeps creating and destroying readers (so its endpoints show up in `ros_discovery_info` but never settle into discovered DDS endpoints) makes the bridge re-push the same gids on every announcement, and the lists grow without bound. On our robot the bridge reached ~2 GB RSS (~65M staged gids) after a few days and got killed.

This only stages a gid when it isn't already in the list, which keeps each list bounded to the distinct undiscovered gids for the node.

Closes #712
