### PR TITLE
fix: keep matching listeners scoped to routes instead of backgrounding them

### DIFF
--- a/zenoh-plugin-ros2dds/src/route_publisher.rs
+++ b/zenoh-plugin-ros2dds/src/route_publisher.rs
@@ -28,6 +28,7 @@ use serde::{Serialize, Serializer};
 use zenoh::{
     key_expr::{keyexpr, OwnedKeyExpr},
     liveliness::LivelinessToken,
+    matching::MatchingListener,
     qos::{CongestionControl, Priority, Reliability},
     sample::Locality,
     Wait,
@@ -81,6 +82,10 @@ pub struct RoutePublisher {
         serialize_with = "serialize_pub_cache"
     )]
     zenoh_publisher: ZPublisher,
+    // Keep the listener scoped to the route. A background listener outlives
+    // this object and can recreate a DDS Reader after the route is removed.
+    #[serde(skip)]
+    matching_listener: Option<MatchingListener<()>>,
     // the local DDS Reader created to serve the route (i.e. re-publish to zenoh message coming from DDS)
     #[serde(serialize_with = "serialize_atomic_entity_guid")]
     dds_reader: Arc<AtomicDDSEntity>,
@@ -109,6 +114,9 @@ pub struct RoutePublisher {
 
 impl Drop for RoutePublisher {
     fn drop(&mut self) {
+        // Stop matching callbacks before deleting the DDS entity and dropping
+        // the publisher captured by the callback.
+        self.matching_listener.take();
         self.deactivate_dds_reader();
     }
 }
@@ -221,7 +229,7 @@ impl RoutePublisher {
         // (copy/move all required args for the callback)
         let dds_reader: Arc<AtomicDDSEntity> = Arc::new(DDS_ENTITY_NULL.into());
 
-        publisher
+        let matching_listener = publisher
             .matching_listener()
             .callback({
                 let dds_reader = dds_reader.clone();
@@ -256,7 +264,6 @@ impl RoutePublisher {
                     }
                 }
             })
-            .background()
             .await
             .map_err(|e| format!("Failed to listen of matching status changes: {e}",))?;
 
@@ -269,6 +276,7 @@ impl RoutePublisher {
                 publisher,
                 cache_size,
             },
+            matching_listener: Some(matching_listener),
             dds_reader,
             priority,
             _type_info: type_info.clone(),

--- a/zenoh-plugin-ros2dds/src/route_service_cli.rs
+++ b/zenoh-plugin-ros2dds/src/route_service_cli.rs
@@ -30,6 +30,7 @@ use zenoh::{
     internal::buffers::{Buffer, ZBuf, ZSlice},
     key_expr::{keyexpr, OwnedKeyExpr},
     liveliness::LivelinessToken,
+    matching::MatchingListener,
     query::{Querier, Reply},
     sample::Locality,
     Wait,
@@ -66,6 +67,10 @@ pub struct RouteServiceCli {
     context: Context,
     #[serde(skip)]
     _zenoh_querier: Arc<Querier<'static>>,
+    // Keep the listener scoped to the route instead of detaching it in the
+    // background, where it can survive route removal.
+    #[serde(skip)]
+    matching_listener: Option<MatchingListener<()>>,
     #[serde(serialize_with = "crate::config::serialize_duration_as_f32")]
     queries_timeout: Duration,
     // the local DDS Reader receiving client's requests and routing them to Zenoh
@@ -85,6 +90,7 @@ pub struct RouteServiceCli {
 
 impl Drop for RouteServiceCli {
     fn drop(&mut self) {
+        self.matching_listener.take();
         self.deactivate();
     }
 }
@@ -131,7 +137,7 @@ impl RouteServiceCli {
         let rep_writer: Arc<AtomicDDSEntity> = Arc::new(DDS_ENTITY_NULL.into());
         let req_reader: Arc<AtomicDDSEntity> = Arc::new(DDS_ENTITY_NULL.into());
 
-        zenoh_querier
+        let matching_listener = zenoh_querier
             .matching_listener()
             .callback({
                 let rep_writer = rep_writer.clone();
@@ -166,7 +172,6 @@ impl RouteServiceCli {
                         }
                 }
             })
-            .background()
             .await
             .map_err(|e| format!("Route Service Client (ROS:{ros2_name} <-> Zenoh:{zenoh_key_expr}): failed to listen of matching status changes: {e}",))?;
 
@@ -176,6 +181,7 @@ impl RouteServiceCli {
             zenoh_key_expr,
             context,
             _zenoh_querier: zenoh_querier,
+            matching_listener: Some(matching_listener),
             queries_timeout,
             rep_writer,
             req_reader,


### PR DESCRIPTION
RoutePublisher and RouteServiceCli declared their matching listeners with .background(), detaching them from the route lifetime. After a route was removed, the listener stayed alive and its callback could recreate a DDS Reader for the removed route, inflating the ROS 2 subscription count on every restart of a native Zenoh subscriber.

Store the returned MatchingListener in the route objects and take it in Drop before deactivating the DDS entity, so callbacks stop as soon as the route is removed.